### PR TITLE
Redis sentinel role support

### DIFF
--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -23,9 +23,9 @@ module ThreeScale
       config.workers_logger_formatter = :text
 
       # Add configuration sections
-      config.add_section(:queues, :master_name, :sentinels,
+      config.add_section(:queues, :master_name, :sentinels, :role,
                          :connect_timeout, :read_timeout, :write_timeout)
-      config.add_section(:redis, :url, :proxy, :sentinels,
+      config.add_section(:redis, :url, :proxy, :sentinels, :role,
                          :connect_timeout, :read_timeout, :write_timeout)
       config.add_section(:analytics_redis, :server,
                          :connect_timeout, :read_timeout, :write_timeout)

--- a/lib/3scale/backend/storage.rb
+++ b/lib/3scale/backend/storage.rb
@@ -46,7 +46,7 @@ module ThreeScale
           private_constant :CONN_WHITELIST
 
           # Parameters regarding target server we will take from a config object
-          URL_WHITELIST = [:url, :proxy, :server, :sentinels].freeze
+          URL_WHITELIST = [:url, :proxy, :server, :sentinels, :role].freeze
           private_constant :URL_WHITELIST
 
           # these are the parameters we will take from a config object
@@ -182,6 +182,9 @@ module ThreeScale
           #   { host: "hostN", port: "portN" }
           # ]
           def cfg_sentinels_handler(options)
+            # get role attr and remove from options
+            # will only be validated and included when sentinels are valid
+            role = options.delete :role
             sentinels = options.delete :sentinels
             # The Redis client can't accept empty string or array of :sentinels
             return options if sentinels.nil? || sentinels.empty?
@@ -205,6 +208,8 @@ module ThreeScale
               end
             end.compact
 
+            # Handle role option when sentinels are validated
+            options[:role] = role if role && !role.empty?
             options
           end
 

--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -19,11 +19,13 @@ ThreeScale::Backend.configure do |config|
   config.internal_api.password = "#{ENV['CONFIG_INTERNAL_API_PASSWORD']}"
   config.queues.master_name = "#{ENV['CONFIG_QUEUES_MASTER_NAME']}"
   config.queues.sentinels = "#{ENV['CONFIG_QUEUES_SENTINEL_HOSTS'] && !ENV['CONFIG_QUEUES_SENTINEL_HOSTS'].empty? ? ENV['CONFIG_QUEUES_SENTINEL_HOSTS'] : ENV['SENTINEL_HOSTS']}"
+  config.queues.role = "#{ENV['CONFIG_QUEUES_SENTINEL_ROLE']}".to_sym
   config.queues.connect_timeout = parse_int_env('CONFIG_QUEUES_CONNECT_TIMEOUT')
   config.queues.read_timeout = parse_int_env('CONFIG_QUEUES_READ_TIMEOUT')
   config.queues.write_timeout = parse_int_env('CONFIG_QUEUES_WRITE_TIMEOUT')
   config.redis.proxy = "#{ENV['CONFIG_REDIS_PROXY']}"
   config.redis.sentinels = "#{ENV['CONFIG_REDIS_SENTINEL_HOSTS']}"
+  config.redis.role = "#{ENV['CONFIG_REDIS_SENTINEL_ROLE']}".to_sym
   config.redis.connect_timeout = parse_int_env('CONFIG_REDIS_CONNECT_TIMEOUT')
   config.redis.read_timeout = parse_int_env('CONFIG_REDIS_READ_TIMEOUT')
   config.redis.write_timeout = parse_int_env('CONFIG_REDIS_WRITE_TIMEOUT')

--- a/test/unit/storage_test.rb
+++ b/test/unit/storage_test.rb
@@ -42,15 +42,111 @@ class StorageTest < Test::Unit::TestCase
     end
   end
 
+  def test_sentinels_connection_string
+    config_obj = {
+      url: 'redis://127.0.0.1:6379/0',
+      sentinels: ',redis://127.0.0.1:26379, ,    , 127.0.0.1:36379,'
+    }
+    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_connector(conn.client)
+    assert_client_config(conn.client, url: config_obj[:url],
+                                      sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                                                  { host: '127.0.0.1', port: 36_379 }])
+  end
+
+  def test_sentinels_connection_string_escaped
+    config_obj = {
+      url: 'redis://127.0.0.1:6379/0',
+      sentinels: 'redis://user:passw\,ord@127.0.0.1:26379 ,127.0.0.1:36379, ,'
+    }
+    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_connector(conn.client)
+    assert_client_config(conn.client, url: config_obj[:url],
+                                      sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                                                  { host: '127.0.0.1', port: 36_379 }])
+  end
+
+  def test_sentinels_connection_array_strings
+    config_obj = {
+      url: 'redis://127.0.0.1:6379/0',
+      sentinels: ['redis://127.0.0.1:26379 ', ' 127.0.0.1:36379', nil]
+    }
+    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_connector(conn.client)
+    assert_client_config(conn.client, url: config_obj[:url],
+                                      sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                                                  { host: '127.0.0.1', port: 36_379 }])
+  end
+
+  def test_sentinels_connection_array_hashes
+    config_obj = {
+      url: 'redis://127.0.1.1:6379/0',
+      sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                  {},
+                  { host: '127.0.0.1', port: 36_379 },
+                  nil]
+    }
+    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_connector(conn.client)
+    assert_client_config(conn.client, url: config_obj[:url],
+                                      sentinels: config_obj[:sentinels].compact.reject(&:empty?))
+  end
+
+  def test_sentinels_malformed_url
+    config_obj = {
+      url: 'redis://127.0.0.1:6379/0',
+      sentinels: 'redis://127.0.0.1:26379,a_malformed_url:1:10'
+    }
+    assert_raise Storage::InvalidURI do
+      Storage.send :new, Storage::Helpers.config_with(config_obj)
+    end
+  end
+
   def test_sentinels_simple_url
     config_obj = {
       url: 'master-name', # url of the sentinel master name conf
       sentinels: 'redis://127.0.0.1:26379'
     }
     conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
-    test_sentinel_connector(conn.client)
-    test_client_config(conn.client, url: "redis://#{config_obj[:url]}",
-                                    sentinels: [{ host: '127.0.0.1', port: 26_379 }])
+    assert_sentinel_connector(conn.client)
+    assert_client_config(conn.client, url: "redis://#{config_obj[:url]}",
+                                      sentinels: [{ host: '127.0.0.1', port: 26_379 }])
+  end
+
+  def test_sentinels_correct_role
+    %i[master slave].each do |role|
+      config_obj = {
+        url: 'redis://master-group',
+        sentinels: 'redis://127.0.0.1:26379',
+        role: role
+      }
+      conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
+      assert_sentinel_connector(conn.client)
+      assert_client_config(conn.client, url: config_obj[:url],
+                                        sentinels: [{ host: '127.0.0.1', port: 26_379 }],
+                                        role: role)
+    end
+  end
+
+  def test_sentinels_role_empty
+    [''.to_sym, '', nil].each do |role|
+      config_obj = {
+        url: 'redis://127.0.0.1:6379/0',
+        sentinels: 'redis://127.0.0.1:26379',
+        role: role
+      }
+      redis_cfg = Storage::Helpers.config_with(config_obj)
+      refute redis_cfg.key?(:role)
+    end
+  end
+
+  def test_role_empty_when_sentinels_does_not_exist
+    config_obj = {
+      url: 'redis://127.0.0.1:6379/0',
+      role: :master
+    }
+    redis_cfg = Storage::Helpers.config_with(config_obj)
+    refute redis_cfg.key?(:role)
   end
 
   def test_redis_no_scheme
@@ -65,66 +161,6 @@ class StorageTest < Test::Unit::TestCase
     end
   end
 
-  def test_sentinels_connection_string
-    config_obj = {
-      url: 'redis://127.0.0.1:6379/0',
-      sentinels: ',redis://127.0.0.1:26379, ,    , 127.0.0.1:36379,'
-    }
-    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
-    assert_sentinel_connector(conn.client)
-    assert_client_config(conn.client, url: config_obj[:url],
-                         sentinels: [{ host: '127.0.0.1', port: 26379 },
-                                     { host: '127.0.0.1', port: 36379 }])
-  end
-
-  def test_sentinels_connection_string_escaped
-    config_obj = {
-      url: 'redis://127.0.0.1:6379/0',
-      sentinels: 'redis://user:passw\,ord@127.0.0.1:26379 ,127.0.0.1:36379, ,'
-    }
-    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
-    assert_sentinel_connector(conn.client)
-    assert_client_config(conn.client, url: config_obj[:url],
-                         sentinels: [{ host: '127.0.0.1', port: 26379 },
-                                     { host: '127.0.0.1', port: 36379 }])
-  end
-
-  def test_sentinels_connection_array_strings
-    config_obj = {
-      url: 'redis://127.0.0.1:6379/0',
-      sentinels: ['redis://127.0.0.1:26379 ', ' 127.0.0.1:36379', nil]
-    }
-    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
-    assert_sentinel_connector(conn.client)
-    assert_client_config(conn.client, url: config_obj[:url],
-                         sentinels: [{ host: '127.0.0.1', port: 26379 },
-                                     { host: '127.0.0.1', port: 36379 }])
-  end
-
-  def test_sentinels_connection_array_hashes
-    config_obj = {
-      url: 'redis://127.0.1.1:6379/0',
-      sentinels: [ { host: '127.0.0.1', port: 26379 },
-                   {},
-                   { host: '127.0.0.1', port: 36379 },
-                   nil]
-    }
-    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
-    assert_sentinel_connector(conn.client)
-    assert_client_config(conn.client, url: config_obj[:url],
-                         sentinels: config_obj[:sentinels].compact.reject(&:empty?))
-  end
-
-  def test_sentinels_malformed_url
-    config_obj = {
-      url: 'redis://127.0.0.1:6379/0',
-      sentinels: 'redis://127.0.0.1:26379,a_malformed_url:1:10'
-    }
-    assert_raise Storage::InvalidURI do
-      Storage.send :new, Storage::Helpers.config_with(config_obj)
-    end
-  end
-
   def test_sentinels_empty
     ['', []].each do |sentinels_val|
       config_obj = {
@@ -132,7 +168,7 @@ class StorageTest < Test::Unit::TestCase
         sentinels: sentinels_val
       }
       redis_cfg = Storage::Helpers.config_with(config_obj)
-      assert !redis_cfg.key?(:sentinels)
+      refute redis_cfg.key?(:sentinels)
     end
   end
 
@@ -149,12 +185,11 @@ class StorageTest < Test::Unit::TestCase
     assert_instance_of Redis::Client::Connector::Sentinel, connector
   end
 
-  def assert_client_config(client, host: nil, port: nil, url: nil, sentinels: nil)
-    raise "bad usage of #{__method__}" unless host || port || url
-    assert_equal client.port, port if port
-    assert_equal client.host, host if host
-    assert_equal client.options[:url], url if url
-    assert_equal client.options[:sentinels], sentinels if sentinels
+  def assert_client_config(client, url:, **conf)
+    assert_equal client.options[:url], url
+    conf.each do |k, v|
+      assert_equal client.options[k], v
+    end
   end
 
   def url(url)

--- a/test/unit/storage_test.rb
+++ b/test/unit/storage_test.rb
@@ -42,6 +42,17 @@ class StorageTest < Test::Unit::TestCase
     end
   end
 
+  def test_sentinels_simple_url
+    config_obj = {
+      url: 'master-name', # url of the sentinel master name conf
+      sentinels: 'redis://127.0.0.1:26379'
+    }
+    conn = Storage.send :orig_new, Storage::Helpers.config_with(config_obj)
+    test_sentinel_connector(conn.client)
+    test_client_config(conn.client, url: "redis://#{config_obj[:url]}",
+                                    sentinels: [{ host: '127.0.0.1', port: 26_379 }])
+  end
+
   def test_redis_no_scheme
     assert_nothing_raised do
       Storage.send :new, url('backend-redis:6379')


### PR DESCRIPTION
Enable sentinels role configuration for stats and resque connections.

Using 3scale_backend.conf config file, role configuration can be read from env vars:
 - ```CONFIG_QUEUES_SENTINEL_ROLE``` for queue connection
 - ```CONFIG_REDIS_SENTINEL_ROLE``` for stats storage connection