### PR TITLE
Makefile: Detect if we are using gnu time

### DIFF
--- a/script/make_report_time.sh
+++ b/script/make_report_time.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 shift  # get rid of the '-c' supplied by make.
 
-\time -o bench.txt -a -f "[%E] : $*" -- sh -c "$*"
+if command time --version > /dev/null 2>&1
+then
+        \command time -o bench.txt -a -f "[%E] : $*" -- sh -c "$*"
+else
+        \echo "$*" >> bench.txt
+        \command time 3>&2 4>> bench.txt 2>&4 sh -c "$* 2>&3"
+fi


### PR DESCRIPTION
Due to differences between bsd time and gnu time command,
the current makefile files to run under Darwin.

This commit disables writing "bench.txt" for non linux systems.