### PR TITLE
Expose to localhost the default port number (3000) of the 3scale_backend listener on the Makefile 'dev' rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ dev-clean-image: dev-clean
 
 .PHONY: dev
 dev: export IMAGE_NAME?=apisonator-dev
+dev: export PORT?= 3000
 dev:
 	@docker history -q $(IMAGE_NAME) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) dev-build
 	@if docker ps --filter name=apisonator-dev | grep -q $(IMAGE_NAME) 2> /dev/null >&2; then \
@@ -48,7 +49,7 @@ dev:
 	@if docker ps -a --filter name=apisonator-dev | grep -q $(IMAGE_NAME) 2> /dev/null >&2; then \
 		docker start -ai apisonator-dev ; \
 	else \
-		docker run -ti -h apisonator-dev -v \
+		docker run -ti -h apisonator-dev --expose=3000 -p $(PORT):3000 -v \
 		$(PROJECT_PATH):$$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'cd && pwd')/apisonator:z \
 		-u $$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'id -u'):$$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'id -g') \
 		--name apisonator-dev $(IMAGE_NAME) /bin/bash ; \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ your local apisonator directory, so you can edit files in your preferred
 environment and still be able to run whatever you need inside the Docker
 container.
 
+The listener service port (3000 by default) is automatically forwarded to the host machine. The `make dev` command can be executed with the environment variable `PORT` set to
+a different desired listener port value to forward on the host machine.
+
 This Docker container is persistent, so your changes will be kept the next time
 you enter it.
 


### PR DESCRIPTION
In order to be able to perform local development testing more easily we expose the default port (3000) of the 3scale_backend listener when executing the Makefile 'dev' rule