### PR TITLE
Add dev-service and dev-service-clean Makefile rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ you enter it.
 Getting rid of the persistent container is done with `make dev-clean`, whereas
 removing its image is done using `make dev-clean-image`.
 
+Alternatively you can start a container with the service running with
+`make dev-service`. This rule is intended for when you want to test
+the service endpoint.
+
 #### Maintain your dependencies up-to-date
 
 Changes in code sometimes translate into changes in dependencies. If that is the

--- a/script/lib/functions
+++ b/script/lib/functions
@@ -69,9 +69,9 @@ function stop_postgresql {
 }
 
 function start_services {
+    start_postgresql
     start_redis
     start_twemproxy
-    start_postgresql
 }
 
 function stop_services {


### PR DESCRIPTION
This rules have been added to be able to start a container with the 3scale_backend service running.

The rule dev-service-clean removes the container.
Also, the dev-clean-image rule has been updated to remove the associated dev-service container too.
Due to now we may have the dev-service and dev container running I have improved the running container detection logic
in the dev-service and dev rules to only match the container name (whole name and not matching prefixes)