### PR TITLE
.gitignore: Ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bundle
 *.gem
+.vscode/
 
 lib/3scale/core
 lib/3scale/core.rb


### PR DESCRIPTION
Add .vscode directory to the .gitignore file. This directory is automatically created for local VSCode configurations.