### PR TITLE
Bugfix/Ensure an application without state can't be saved

### DIFF
--- a/app/api/internal/applications.rb
+++ b/app/api/internal/applications.rb
@@ -18,8 +18,13 @@ module ThreeScale
           end
           app_attrs[:service_id] = service_id
           app_attrs[:id] = id
-          app = Application.save(app_attrs)
-          [201, headers, { status: :created, application: app.to_hash }.to_json]
+          begin
+            app = Application.save(app_attrs)
+          rescue ApplicationHasNoState => e
+            [400, headers, { status: :bad_request, error: e.message }.to_json]
+          else
+            [201, headers, { status: :created, application: app.to_hash }.to_json]
+          end
         end
 
         put '/:id' do |service_id, id|
@@ -27,8 +32,13 @@ module ThreeScale
           modified = Application.exists?(service_id, id)
           app_attrs[:service_id] = service_id
           app_attrs[:id] = id
-          app = Application.save(app_attrs)
-          { status: modified ? :modified : :created, application: app.to_hash }.to_json
+          begin
+            app = Application.save(app_attrs)
+          rescue ApplicationHasNoState => e
+            [400, headers, { status: :bad_request, error: e.message }.to_json]
+          else
+            { status: modified ? :modified : :created, application: app.to_hash }.to_json
+          end
         end
 
         delete '/:id' do |service_id, id|

--- a/lib/3scale/backend/application.rb
+++ b/lib/3scale/backend/application.rb
@@ -178,6 +178,8 @@ module ThreeScale
       end
 
       def save
+        raise ApplicationHasNoState.new(id) if !state
+
         storage.pipelined do
           persist_attributes
           persist_set

--- a/lib/3scale/backend/errors.rb
+++ b/lib/3scale/backend/errors.rb
@@ -373,5 +373,11 @@ module ThreeScale
       end
     end
 
+    class ApplicationHasNoState < BadRequest
+      def initialize(id)
+        super %(Application with id="#{id}" has no state )
+      end
+    end
+
   end
 end

--- a/spec/acceptance/api/internal/applications_api_spec.rb
+++ b/spec/acceptance/api/internal/applications_api_spec.rb
@@ -85,6 +85,17 @@ resource 'Applications (prefix: /services/:service_id/applications)' do
       # The returned data should not contain *some_param* attribute
       expect(app.to_hash).to eq application.merge(user_required: false)
     end
+
+    context 'with an application that has no state' do
+      let (:state) { nil }
+
+      example_request 'Trying to create the application' do
+        expect(status).to eq 400
+        expect(response_json['status']).to eq 'bad_request'
+        expect(response_json['error']).to match /has no state/i
+      end
+    end
+
   end
 
   put '/services/:service_id/applications/:id' do
@@ -155,6 +166,16 @@ resource 'Applications (prefix: /services/:service_id/applications)' do
         expect(status).to eq 400
         expect(response_json['status']).to eq 'error'
         expect(response_json['error']).to match /missing parameter/i
+      end
+    end
+
+    context 'with an application that has no state' do
+      let (:state) { nil }
+
+      example_request 'Trying to create/update the application' do
+        expect(status).to eq 400
+        expect(response_json['status']).to eq 'bad_request'
+        expect(response_json['error']).to match /has no state/i
       end
     end
   end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -47,6 +47,14 @@ class ApplicationTest < Test::Unit::TestCase
     assert_equal 'almost_awesome', newapp.plan_name
   end
 
+  test '#save raises an exception if no state is defined' do
+    assert_raise ApplicationHasNoState do
+      Application.save(service_id: '2001', id: '8011',
+                       plan_id: '3001', plan_name: 'awesome',
+                       redirect_url: 'bla')
+    end
+  end
+
   test '.load correctly creates an Application instance' do
     Application.save(service_id: '2001', id: '8012',
                      state: :active, redirect_url: 'bla')


### PR DESCRIPTION
When saving an application, the existence of the application's state attribute was not checked.
Update Application logic to check for this and return an exception if not specified.