### PR TITLE
exception_catcher: return XML response body when invalid %encoding is detected

### DIFF
--- a/lib/3scale/backend/rack/exception_catcher.rb
+++ b/lib/3scale/backend/rack/exception_catcher.rb
@@ -21,6 +21,10 @@ module ThreeScale
           'invalid byte sequence in UTF-8'.freeze
         private_constant :INVALID_BYTE_SEQUENCE_ERR_MSG
 
+        INVALID_PERCENT_ENCODING_ERR_MSG = 'Invalid query parameters: '\
+        'invalid %-encoding'.freeze
+        private_constant :INVALID_PERCENT_ENCODING_ERR_MSG
+
         # Raised with invalid hash params such as:
         # usage[]=1&usage[metric]=1.
         # This is not the whole message. It contains the affected param at the end.
@@ -119,6 +123,9 @@ module ThreeScale
           elsif resp_body.start_with?(EXPECTED_HASH_ERR_MSG)
             delete_sinatra_error! env
             resp = respond_with 400, Backend::BadRequest.new.to_xml
+          elsif resp_body.start_with?(INVALID_PERCENT_ENCODING_ERR_MSG)
+            delete_sinatra_error! env
+            resp = respond_with 400, Backend::BadRequest.new(INVALID_PERCENT_ENCODING_ERR_MSG).to_xml
           end
 
           resp

--- a/test/integration/listener_test.rb
+++ b/test/integration/listener_test.rb
@@ -47,6 +47,21 @@ class ListenerTest < Test::Unit::TestCase
     assert_equal 'required_params_missing', node['code']
   end
 
+  def test_invalid_percent_encoding
+    # We pass a string and not a hash as a parameter due to
+    # the rack-test library performs modifications to the passed values
+    # (changes encoding, content-type, etc...) when a hash is passed,
+    # and we do not want to have any modifications to the content in this
+    # case.
+    post '/transactions.xml', 'testparam=value1%'
+
+    assert_equal 400, last_response.status
+
+    node = xml.at('error')
+    assert_equal Rack::ExceptionCatcher.const_get(:INVALID_PERCENT_ENCODING_ERR_MSG), node.content
+    assert_equal 'bad_request', node['code']
+  end
+
   def test_malformed_hash_param
     get '/transactions/authorize.xml', :provider_key => 'abc',
                                        :usage => { '' => 1, 'hits' => 1 }


### PR DESCRIPTION
When performing a request with an invalid percentage-encoding
format we now return an XML from a Backend::Error type of error.
Previously when an invalid percentage-encoding was detected
the response was a sinatra error.

This has been done in the same way that was done with the response error management of INVALID_BYTE_SEQUENCE_ERR_MSG