### PR TITLE
Feature/configurable current notify metrics

### DIFF
--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -12,6 +12,11 @@ module ThreeScale
       end
     end
 
+    CONFIG_MASTER_METRICS_TRANSACTIONS_DEFAULT = "transactions".freeze
+    private_constant :CONFIG_MASTER_METRICS_TRANSACTIONS_DEFAULT
+    CONFIG_MASTER_METRICS_TRANSACTIONS_AUTHORIZE_DEFAULT = "transactions/authorize".freeze
+    private_constant :CONFIG_MASTER_METRICS_TRANSACTIONS_AUTHORIZE_DEFAULT
+
     @configuration = Configuration::Loader.new
 
     # assign @configuration first, since code can depend on the attr_reader
@@ -35,6 +40,11 @@ module ThreeScale
       config.add_section(:statsd, :host, :port)
       config.add_section(:internal_api, :user, :password)
       config.add_section(:oauth, :max_token_size)
+      config.add_section(:master, :metrics)
+
+      # Configure nested fields
+      master_metrics = [:transactions, :transactions_authorize]
+      config.master.metrics = Struct.new(*master_metrics).new
 
       # Default config
       config.master_service_id  = 1
@@ -59,6 +69,22 @@ module ThreeScale
         '~/.3scale_backend.conf',
         ENV['CONFIG_FILE']
       ].compact)
+
+      # Assign default values to some configuration values
+      # that might been set in the config file but their
+      # environment variables not, or not have been set
+			# but should always have at least a default value.
+			# Also make sure that what we have is a String, just in case
+      # a type of data different than a String has been
+			# assigned to this configuration parameter
+      config.master.metrics.transactions = config.master.metrics.transactions.to_s
+      if config.master.metrics.transactions.empty?
+        config.master.metrics.transactions = CONFIG_MASTER_METRICS_TRANSACTIONS_DEFAULT
+      end
+      config.master.metrics.transactions_authorize = config.master.metrics.transactions_authorize.to_s
+      if config.master.metrics.transactions_authorize.empty?
+        config.master.metrics.transactions_authorize = CONFIG_MASTER_METRICS_TRANSACTIONS_AUTHORIZE_DEFAULT
+      end
 
       # can_create_event_buckets is just for our SaaS analytics system.
       # If SaaS has been set to false, we need to disable buckets too.

--- a/lib/3scale/backend/transactor/notify_batcher.rb
+++ b/lib/3scale/backend/transactor/notify_batcher.rb
@@ -12,21 +12,17 @@ module ThreeScale
         include Resque::Helpers
         include Configurable
 
-        METRIC_AUTHORIZE = 'transactions/authorize'.freeze
-        METRIC_TRANSACTIONS = 'transactions'.freeze
-        private_constant :METRIC_AUTHORIZE, :METRIC_TRANSACTIONS
-
         def notify_authorize(provider_key)
-          notify(provider_key, METRIC_AUTHORIZE => 1)
+          notify(provider_key, configuration.master.metrics.transactions_authorize => 1)
         end
 
         def notify_authrep(provider_key, transactions)
-          notify(provider_key, METRIC_AUTHORIZE => 1,
-                               METRIC_TRANSACTIONS => transactions)
+          notify(provider_key, configuration.master.metrics.transactions_authorize => 1,
+                 configuration.master.metrics.transactions => transactions)
         end
 
         def notify_report(provider_key, transactions)
-          notify(provider_key, METRIC_TRANSACTIONS => transactions)
+          notify(provider_key, configuration.master.metrics.transactions => transactions)
         end
 
         def key_for_notifications_batch

--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -43,6 +43,8 @@ ThreeScale::Backend.configure do |config|
   config.redshift.user = "#{ENV['CONFIG_REDSHIFT_USER']}"
   config.redshift.password = "#{ENV['CONFIG_REDSHIFT_PASSWORD']}"
   config.master_service_id = "#{ENV['CONFIG_MASTER_SERVICE_ID']}"
+  config.master.metrics.transactions = "#{ENV['CONFIG_MASTER_METRICS_TRANSACTIONS']}"
+  config.master.metrics.transactions_authorize = "#{ENV['CONFIG_MASTER_METRICS_TRANSACTIONS_AUTHORIZE']}"
   config.hoptoad.service = ENV['CONFIG_HOPTOAD_SERVICE'] ? "#{ENV['CONFIG_HOPTOAD_SERVICE']}" : nil
   config.hoptoad.api_key = "#{ENV['CONFIG_HOPTOAD_API_KEY']}"
   config.events_hook = "#{ENV['CONFIG_EVENTS_HOOK']}"


### PR DESCRIPTION
We make current master service metrics configurable via the 3scale_backend.conf file by setting environment variables.

Current tests are passing but it is a change that is important to be sure it does not break anything. Probably some kind of unit test would be a good idea? I don't find/can't see any configuration unit test