### PR TITLE
Add more error messages for the transactions.xml endpoint 

### DIFF
--- a/lib/3scale/backend/errors.rb
+++ b/lib/3scale/backend/errors.rb
@@ -354,5 +354,24 @@ module ThreeScale
         super %(invalid Content-Type: #{content_type})
       end
     end
+
+    class TransactionsIsBlank < BadRequest
+      def initialize
+        super 'transactions parameter is blank'.freeze
+      end
+    end
+
+    class TransactionsFormatInvalid < BadRequest
+      def initialize
+        super 'transactions format is invalid'.freeze
+      end
+    end
+
+    class TransactionsHasNilTransaction < BadRequest
+      def initialize
+        super 'transactions has a nil transaction'.freeze
+      end
+    end
+
   end
 end

--- a/lib/3scale/backend/listener.rb
+++ b/lib/3scale/backend/listener.rb
@@ -9,6 +9,8 @@ module ThreeScale
       enable :raise_errors
       disable :show_exceptions
 
+      include Logging
+
       ## ------------ DOCS --------------
       ##~ namespace = ENV['SAAS_SWAGGER'] == "1" ? "Service Management API" : "Service Management API (on-premises)"
       ##~ sapi = source2swagger.namespace(namespace)
@@ -416,7 +418,10 @@ module ThreeScale
         check_post_content_type!
 
         # 403 Forbidden for consistency (but we should return 400 Bad Request)
-        halt 403 if params.nil?
+        if params.nil?
+          logger.notify("listener: params hash is nil in method '/transactions.xml'")
+          halt 403
+        end
 
         # returns 403 when no provider key is given, even if other params have an invalid encoding
         provider_key = params[:provider_key] ||

--- a/lib/3scale/backend/listener.rb
+++ b/lib/3scale/backend/listener.rb
@@ -433,12 +433,7 @@ module ThreeScale
         check_params_value_encoding!(params, REPORT_EXPECTED_PARAMS)
 
         transactions = params[:transactions]
-
-        if blank?(transactions) ||
-            !transactions.is_a?(Hash) ||
-            transactions.any? { |_id, data| data.nil? }
-          halt 400
-        end
+        check_transactions_validity(transactions)
 
         Transactor.report(provider_key, params[:service_id], transactions, response_code: 202, request: request_info)
         202
@@ -579,6 +574,20 @@ module ThreeScale
       def check_post_content_type!
         ctype = request.media_type
         raise ContentTypeInvalid, ctype if invalid_post_content_type?(ctype)
+      end
+
+      def check_transactions_validity(transactions)
+        if blank?(transactions)
+          raise TransactionsIsBlank
+        end
+
+        if !transactions.is_a?(Hash)
+          raise TransactionsFormatInvalid
+        end
+
+        if transactions.any? { |_id, data| data.nil? }
+          raise TransactionsHasNilTransaction
+        end
       end
 
       def application

--- a/test/integration/report_test.rb
+++ b/test/integration/report_test.rb
@@ -831,7 +831,14 @@ class ReportTest < Test::Unit::TestCase
                             1 => nil }
 
     assert_equal 400, last_response.status
-    assert_equal '', last_response.body
+    assert_not_equal '', last_response.body
+
+    assert_error_resp_with_exc(ThreeScale::Backend::TransactionsHasNilTransaction.new)
+  end
+
+  test 'params is not nil if no parameters are passed' do
+    post '/transactions.xml'
+    assert_not_nil last_request.params
   end
 
   test 'returns 403 if provider key is missing' do
@@ -870,7 +877,9 @@ class ReportTest < Test::Unit::TestCase
       :transactions => 'i_am_a_string_with_valid_encoding'
 
     assert_equal 400, last_response.status
-    assert_equal '', last_response.body
+    assert_not_equal '', last_response.body
+
+    assert_error_resp_with_exc(ThreeScale::Backend::TransactionsFormatInvalid.new)
   end
 
   test 'returns 400 and not valid data msg when params have an invalid encoding' do


### PR DESCRIPTION
We now return a proper 400 error code with some information in XML
format when the following situations are detected:

· The transactions parameter is blank
· The transactions parameter is not a hash
· Some transaction of the transactions parameter is nil

Also, we have added temporary logging to confirm that the params hash can never be nil and we'll remove the checking of the nil value and the logging if we do not detect related logs for a while.