### PR TITLE
usage_limit: remove seconds from periods set

### DIFF
--- a/lib/3scale/backend/usage_limit.rb
+++ b/lib/3scale/backend/usage_limit.rb
@@ -3,7 +3,7 @@ module ThreeScale
     class UsageLimit
       include Storable
 
-      PERIODS = Period::ALL_DESC
+      PERIODS = (Period::ALL_DESC - [Period::Second]).freeze
 
       attr_accessor :service_id, :plan_id, :metric_id, :period, :value
 

--- a/test/unit/usage_limit_test.rb
+++ b/test/unit/usage_limit_test.rb
@@ -75,6 +75,19 @@ class UsageLimitTest < Test::Unit::TestCase
     assert usage_limits.empty?, 'Expected usage_limits to be empty'
   end
 
+  def test_usage_limit_periods_do_not_include_second
+    assert_nil(UsageLimit::PERIODS.find { |period| period == :second })
+  end
+
+  def test_save_refuses_second_as_period
+    UsageLimit.save(service_id: 2001,
+                    plan_id: 3001,
+                    metric_id: 4001,
+                    second: 100)
+
+    assert_nil UsageLimit.load_value(2001, 3001, 4001, :second)
+  end
+
   def test_load_value
     UsageLimit.save(:service_id => 2001,
                     :plan_id    => 3001,


### PR DESCRIPTION
"seconds" level of granularity does not exist for usage limits. It was tried to load and never found.