### PR TITLE
Fix default notification batch when left unset

### DIFF
--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -10,7 +10,19 @@ module ThreeScale
       def configure
         yield configuration
       end
+
+      private
+
+      def parse_int(value, default)
+        case value
+        when "", nil, false then default
+        else Integer(value)
+        end
+      end
     end
+
+    NOTIFICATION_BATCH_DEFAULT = 10000
+    private_constant :NOTIFICATION_BATCH_DEFAULT
 
     CONFIG_MASTER_METRICS_TRANSACTIONS_DEFAULT = "transactions".freeze
     private_constant :CONFIG_MASTER_METRICS_TRANSACTIONS_DEFAULT
@@ -49,10 +61,6 @@ module ThreeScale
       # Default config
       config.master_service_id  = 1
 
-      ## this means that there will be a NotifyJob for every X notifications (this is
-      ## the call to master)
-      config.notification_batch = 10000
-
       # This setting controls whether the listener can create event buckets in
       # Redis. We do not want all the listeners creating buckets yet, as we do
       # not know exactly the rate at which we can send events to Kinesis
@@ -69,6 +77,11 @@ module ThreeScale
         '~/.3scale_backend.conf',
         ENV['CONFIG_FILE']
       ].compact)
+
+      ## this means that there will be a NotifyJob for every X notifications (this is
+      ## the call to master)
+      config.notification_batch = parse_int(config.notification_batch,
+                                            NOTIFICATION_BATCH_DEFAULT)
 
       # Assign default values to some configuration values
       # that might been set in the config file but their

--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -34,7 +34,7 @@ ThreeScale::Backend.configure do |config|
   config.kinesis_stream_name = "#{ENV['CONFIG_KINESIS_STREAM_NAME']}"
   config.kinesis_region = "#{ENV['CONFIG_KINESIS_REGION']}"
   config.stats.bucket_size = ENV['CONFIG_STATS_BUCKET_SIZE'].to_i
-  config.notification_batch = ENV['CONFIG_NOTIFICATION_BATCH'].to_i
+  config.notification_batch = "#{ENV['CONFIG_NOTIFICATION_BATCH']}"
   config.log_path = "#{ENV['CONFIG_LOG_PATH']}"
   config.can_create_event_buckets = ENV['CONFIG_CAN_CREATE_EVENT_BUCKETS'].to_s == 'true' ? true : false
   config.redshift.host = "#{ENV['CONFIG_REDSHIFT_HOST']}"


### PR DESCRIPTION
The `notification_batch` setting would be set to 0 when unset in the configuration, which would force lots of `NotifyJob`s to be created. Make it default to a reasonable value when not specified.