### PR TITLE
failed_jobs_scheduler: Use Redis Resque instead of Storage for distributed lock

### DIFF
--- a/lib/3scale/backend/failed_jobs_scheduler.rb
+++ b/lib/3scale/backend/failed_jobs_scheduler.rb
@@ -66,7 +66,7 @@ module ThreeScale
 
         def dist_lock
           @dist_lock ||= DistributedLock.new(
-              self.name, TTL_RESCHEDULE_S, Storage.instance)
+              self.name, TTL_RESCHEDULE_S, Resque.redis)
         end
 
         def time_for_another_reschedule?(ttl_expiration_time)


### PR DESCRIPTION
Currently the Redis Distributed Lock is set on the Redis Storage
when the failed jobs scheduler is executed. However, this not allows
to have multiple failed jobs schedulers in execution at the
same time pointing to different Resque servers. Moving the distributed
lock to the Resque server itself solves this problem.