### PR TITLE
Gemfiles: update Nokogiri to 1.8.3

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -17,7 +17,7 @@ end
 group :test do
   gem 'benchmark-ips', '~> 2.7.2'
   gem 'mocha',         '~> 1.3'
-  gem 'nokogiri',      '~> 1.8.2'
+  gem 'nokogiri',      '~> 1.8.3'
   gem 'pkg-config',    '~> 1.1.7'
   gem 'rack-test',     '~> 0.8.2'
   gem 'resque_unit',   '~> 0.4.4', source: 'https://rubygems.org'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     pg (0.20.0)
     pkg-config (1.1.9)
@@ -217,7 +217,7 @@ DEPENDENCIES
   license_finder (~> 3.0.4)
   license_finder_xml_reporter!
   mocha (~> 1.3)
-  nokogiri (~> 1.8.2)
+  nokogiri (~> 1.8.3)
   pg (= 0.20.0)
   pkg-config (~> 1.1.7)
   pry (~> 0.11.3)

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -99,7 +99,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     pkg-config (1.1.9)
     power_assert (1.1.1)
@@ -199,7 +199,7 @@ DEPENDENCIES
   license_finder (~> 3.0.4)
   license_finder_xml_reporter!
   mocha (~> 1.3)
-  nokogiri (~> 1.8.2)
+  nokogiri (~> 1.8.3)
   pkg-config (~> 1.1.7)
   pry (~> 0.11.3)
   pry-byebug (~> 3.5.1)


### PR DESCRIPTION
This version includes an upgraded libxml2 fixing yet again more security issues.