### PR TITLE
Implement Service's Users removal

### DIFF
--- a/app/api/internal/users.rb
+++ b/app/api/internal/users.rb
@@ -44,6 +44,16 @@ module ThreeScale
             [400, headers, { status: :error, error: e.message }.to_json]
           end
         end
+
+        delete '' do |service_id|
+          begin
+            User.delete_all(service_id)
+            { status: :deleted}.to_json
+          rescue => e
+            [400, headers, { status: :error, error: e.message }.to_json]
+          end
+        end
+
       end
     end
   end

--- a/lib/3scale/backend/service.rb
+++ b/lib/3scale/backend/service.rb
@@ -257,7 +257,6 @@ module ThreeScale
 
       def delete_attributes
         keys = ATTRIBUTES.map { |attr| storage_key(attr) }
-        keys << storage_key(:user_set)
         keys << storage_key_by_provider(:id) if default_service?
         storage.del keys
       end

--- a/lib/3scale/backend/storage.rb
+++ b/lib/3scale/backend/storage.rb
@@ -12,6 +12,12 @@ module ThreeScale
       UnspecifiedURIScheme = Class.new Error
       private_constant :UnspecifiedURIScheme
 
+      # Constant used for when batching of operations
+      # is desired/needed. Batching is performed when a lot
+      # of storage operations are need to be performed and we
+      # want to minimize database blocking of other clients
+      BATCH_SIZE = 400
+
       class UnspecifiedURI < Error
         def initialize
           super "Redis URL not specified with url, " \

--- a/lib/3scale/backend/user.rb
+++ b/lib/3scale/backend/user.rb
@@ -82,8 +82,27 @@ module ThreeScale
         storage.del(self.key(service_id, username))
       end
 
+      def self.delete_all(service_id)
+        service = Service.load_by_id(service_id)
+        raise UserRequiresValidService if service.nil?
+        current_scan_cursor_position = "0"
+        finished = false
+        users_set_key = service_users_set_key(service_id)
+        while !finished
+          (current_scan_cursor_position, current_usernames) =
+            storage.sscan(users_set_key, current_scan_cursor_position,
+                          { count: Storage::BATCH_SIZE })
+          delete_users_in_batch(service_id,  current_usernames)
+          finished = current_scan_cursor_position == "0"
+        end
+      end
+
       def self.key(service_id, username)
         "service:#{service_id}/user:#{username}"
+      end
+
+      def self.service_users_set_key(service_id)
+        "service/id:#{service_id}/user_set"
       end
 
       def to_hash
@@ -140,6 +159,20 @@ module ThreeScale
       def self.clear_cache(service_id, user_id)
         key = Memoizer.build_key(self, :load_or_create!, service_id, user_id)
         Memoizer.clear key
+      end
+
+      def self.delete_users_in_batch(service_id, usernames)
+        if usernames.size != 0
+          usernames.each do |username|
+            clear_cache(service_id, username)
+          end
+          service_usernames_keys = usernames.map { |username| self.key(service_id, username) }
+          storage.pipelined do
+            storage.del(service_usernames_keys)
+            storage.srem(self.service_users_set_key(service_id), usernames)
+          end
+
+        end
       end
 
       def self.validate_attributes(attributes)

--- a/spec/acceptance/api/internal/users_api_spec.rb
+++ b/spec/acceptance/api/internal/users_api_spec.rb
@@ -144,4 +144,13 @@ resource 'Users (prefix: /services/:service_id/users)' do
     end
   end
 
+  delete '/services/:service_id/users' do
+    parameter :service_id, 'Service ID', required: true
+
+    example_request 'Deleting all Users of a Service' do
+      expect(status).to eq 200
+      expect(response_json['status']).to eq 'deleted'
+      expect(ThreeScale::Backend::User.exists?(service_id, username)).to be false
+    end
+  end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -119,4 +119,32 @@ class UserTest < Test::Unit::TestCase
 
     assert_equal metrics, user.load_metric_names
   end
+
+  test '.delete_all removes all the Users of a Service' do
+    Service.save!(id: 7003, provider_key: 'test_provkey', default_service: false)
+    Service.save!(id: 7004, provider_key: 'test_provkey', default_service: false)
+    num_users = Storage::BATCH_SIZE + 1
+    num_users.times do |i|
+      User.save! username: "username#{i+1}", service_id: 7003, plan_id: '1001',
+                 plan_name: 'planname'
+    end
+    User.save! username: "username_differentservice", service_id: 7004,
+               plan_id: '1001',plan_name: 'planname'
+
+    User.delete_all(7003)
+
+    num_users.times do |i|
+      assert_equal User.exists?(7003, "username#{i+1}"), false
+    end
+    assert_equal User.exists?(7004, "username_differentservice"), true
+  end
+
+  test '.delete_all does not crash when a Service does not have any user' do
+    Service.save!(id: 7003, provider_key: 'test_provkey', default_service: false)
+
+    assert_nothing_raised do
+      User.delete_all(7003)
+    end
+
+  end
 end


### PR DESCRIPTION
Provide a method to delete all Users of a given Service.

Also provide the HTTP method 'DELETE /services/:service_id/users/all' via Internal API in order to provide this to apisonator administrators.

The decision to NOT delete the Users of the Service when removing a Service is intentional. This has been done to follow coherence like with other entities that are accessible and manageable via Internal API, like with Application, Metrics, Application Keys, etc...

The removal of the Users of the Service has been done taking into account that the number of users of a Service can be big and a batching strategy has been followed.