### PR TITLE
service: Fix set a Service as active when no entry in the DB is found

### DIFF
--- a/lib/3scale/backend/service.rb
+++ b/lib/3scale/backend/service.rb
@@ -238,6 +238,13 @@ module ThreeScale
       def active?
         state == :active
       end
+      alias_method :active, :active?
+
+      def active=(value)
+        self.state = value ? :active : :suspended
+      end
+
+      private
 
       def state=(value)
         # only :active or nil will be considered as :active
@@ -246,8 +253,6 @@ module ThreeScale
         # this change
         @state = value.nil? || value.to_sym == :active ? :active : :suspended
       end
-
-      private
 
       def delete_attributes
         keys = ATTRIBUTES.map { |attr| storage_key(attr) }

--- a/lib/3scale/backend/service.rb
+++ b/lib/3scale/backend/service.rb
@@ -176,8 +176,15 @@ module ThreeScale
       end
 
       def initialize(attributes = {})
-        # default state
-        @state = :active
+        # :state is set as active in this method when:
+        # - The state key is not present in the attributes hash
+        # - The state key is present in the attributes hash but it has
+        #   the nil value
+        # This is done in order to not break compatibility for existing
+        # Services saved in the database, that do not contain the state
+        # key.
+        attributes[:state] ||= :active
+
         super(attributes)
       end
 
@@ -233,8 +240,11 @@ module ThreeScale
       end
 
       def state=(value)
-        # anything but :active will be suspended
-        @state = value.nil? || value.to_sym != :active ? :suspended : :active
+        # only :active or nil will be considered as :active
+        # we assume nil is active because not having a state in an
+        # existing service means that is active in Services created before
+        # this change
+        @state = value.nil? || value.to_sym == :active ? :active : :suspended
       end
 
       private

--- a/spec/acceptance/api/internal/services_api_spec.rb
+++ b/spec/acceptance/api/internal/services_api_spec.rb
@@ -55,7 +55,7 @@ resource 'Services (prefix: /services)' do
         example_request 'Get Service by ID' do
           expect(status).to eq 200
           expect(response_json['service']['id']).to eq id
-          expect(response_json['service']['state']).to eq 'suspended'
+          expect(response_json['service']['state']).to eq 'active'
         end
       end
       context 'when state is suspended' do

--- a/spec/acceptance/api/internal/services_api_spec.rb
+++ b/spec/acceptance/api/internal/services_api_spec.rb
@@ -67,26 +67,13 @@ resource 'Services (prefix: /services)' do
           expect(response_json['service']['state']).to eq state.to_s
         end
       end
-      context 'with an service that has invalid state in db' do
+      context 'when state is set to an invalid state' do
+        let(:state) { :not_valid_state }
         let(:id) { otherid }
-        let(:storage) { ThreeScale::Backend::Storage.instance }
-        example 'Get Service by ID should return inactive state' do
-          storage.set ThreeScale::Backend::Service.storage_key(id, 'state'), 'invalid_state'
-          do_request(id: id)
+        example_request 'Get Service by ID' do
           expect(status).to eq 200
           expect(response_json['service']['id']).to eq id
           expect(response_json['service']['state']).to eq 'suspended'
-        end
-      end
-      context 'with an service that has no state in db' do
-        let(:id) { otherid }
-        let(:storage) { ThreeScale::Backend::Storage.instance }
-        example 'Get Service by ID should return inactive state' do
-          storage.del ThreeScale::Backend::Service.storage_key(id, 'state')
-          do_request(id: id)
-          expect(status).to eq 200
-          expect(response_json['service']['id']).to eq id
-          expect(response_json['service']['state']).to eq 'active'
         end
       end
     end

--- a/spec/acceptance/api/internal/services_api_spec.rb
+++ b/spec/acceptance/api/internal/services_api_spec.rb
@@ -78,6 +78,17 @@ resource 'Services (prefix: /services)' do
           expect(response_json['service']['state']).to eq 'suspended'
         end
       end
+      context 'with an service that has no state in db' do
+        let(:id) { otherid }
+        let(:storage) { ThreeScale::Backend::Storage.instance }
+        example 'Get Service by ID should return inactive state' do
+          storage.del ThreeScale::Backend::Service.storage_key(id, 'state')
+          do_request(id: id)
+          expect(status).to eq 200
+          expect(response_json['service']['id']).to eq id
+          expect(response_json['service']['state']).to eq 'active'
+        end
+      end
     end
   end
 

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -480,6 +480,40 @@ module ThreeScale
           Service.delete_by_id(service_id)
         end
       end
+
+      describe '#active=' do
+        it 'when set to true, active? returns true' do
+          [
+            { state: :suspended, id: '9001', default_service: false },
+            { state: :active, id: '9001', default_service: false },
+            { state: :something, id: '9001', default_service: false },
+            { state: nil, id: '9001', default_service: false },
+            { state: "", id: '9001', default_service: false },
+            { id: '9001', default_service: false}
+          ].each do |svc_attrs|
+            service = Service.save!(svc_attrs)
+            service.active = true
+            expect(service.active?).to be true
+            Service.delete_by_id('9001')
+          end
+        end
+
+        it 'when set to false, active? returns false' do
+          [
+            { state: :suspended, id: '9001', default_service: false },
+            { state: :active, id: '9001', default_service: false },
+            { state: :something, id: '9001', default_service: false },
+            { state: nil, id: '9001', default_service: false },
+            { state: "", id: '9001', default_service: false },
+            { id: '9001', default_service: false}
+          ].each do |svc_attrs|
+            service = Service.save!(svc_attrs)
+            service.active = false
+            expect(service.active?).to be false
+            Service.delete_by_id('9001')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is a bugfix commit.

This comes from the change introduced in https://github.com/3scale/apisonator/pull/35

Currently when a Service existed in the
database but had no 'state' entry then was marked as :suspended.
That breaks compatibility with previously existing Services.
With this commit existing Services in the database that have no
'state' entry in the database are marked as :active to ensure
compatibility.

With this changes the following situations will happen:

 * If a Service is loaded from the database and the database does not have the state entry, then it is loaded as an active Service
 * If a Service is loaded from the database and the database has a state entry but the value of the entry is not active then it is marked as suspended
* If a Service is created as an object directly (with the initialize method) and does not have the state attribute in the attributes hash that is received as a parameter then it is marked as active
* **If a Service is created as an object directly (with the initialize method), does have the state attribute and it is nil then the active state is assigned to it.**
* If a Service is created as an object directly (with the initialize method), does have the state attribute and it is a non-nil value that is not active then it is marked as suspended.
* If a Service is created as an object directly (with the initialize method), and does have the state attribute and it is defined as active then it is marked as active
* If the 'state=' instance method is called with a nil or active value then the Service is marked as active. Otherwise is marked as suspended

On the previous points an important situation happens: An input state attribute that is nil is considered as active too. This has been done to follow coherence with the current situation of the Services, where not having a state set to a Service means that it is active.