### PR TITLE
queue_storage: allow defining Resque configuration without sentinels

### DIFF
--- a/lib/3scale/backend/queue_storage.rb
+++ b/lib/3scale/backend/queue_storage.rb
@@ -2,24 +2,14 @@ module ThreeScale
   module Backend
     class QueueStorage
       def self.connection(env, cfg)
-        init_params = {}
-        if !%w(development test).include?(env)
-          raise 'Configuration must have a valid queues section' unless valid_cfg? cfg
-          init_params[:url] = cfg.queues.master_name
-        else
+        init_params = { url: cfg.queues && cfg.queues.master_name }
+        if %w(development test).include?(env)
           init_params[:default_url] = '127.0.0.1:6379'
         end
-
         options = Backend::Storage::Helpers.config_with(cfg.queues,
                                                         options: init_params)
 
         Redis.new options
-      end
-
-      private
-
-      def self.valid_cfg?(cfg)
-        cfg.queues && cfg.queues.master_name && cfg.queues.sentinels
       end
     end
   end

--- a/spec/unit/queue_storage_spec.rb
+++ b/spec/unit/queue_storage_spec.rb
@@ -22,7 +22,7 @@ module ThreeScale
 
           context 'with a invalid configuration' do
             it 'returns an exception' do
-              expect { conn }.to raise_error RuntimeError
+              expect { conn }.to raise_error(StandardError)
             end
           end
 


### PR DESCRIPTION
This allows to configure a Redis Resque without defining sentinels.
This is the case for example when Redis ElastiCache is used.

While at it also allow picking up the configuration in dev/test modes.