### PR TITLE
service: Delete all service errors when removed

### DIFF
--- a/lib/3scale/backend/service.rb
+++ b/lib/3scale/backend/service.rb
@@ -219,6 +219,7 @@ module ThreeScale
       def delete_data
         delete_from_lists
         delete_attributes
+        ErrorStorage.delete_all(id)
       end
 
       def to_hash

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -399,6 +399,20 @@ module ThreeScale
           expect(Service.default_id(service.provider_key)).to eq '7002'
         end
 
+        it 'deletes all service errors' do
+          Service.save! id: 7002, provider_key: 'foo', default_service: true
+          ErrorStorage.store(service.id, ApplicationNotFound.new('foo'))
+          ErrorStorage.store(service.id, ApplicationNotFound.new('foo2'))
+
+          expect { Service.delete_by_id(service.id) }
+            .to change { ErrorStorage.count(service.id) }.from(2).to(0)
+        end
+
+        it 'does not raise an exception when deleting a service without errors' do
+          Service.save! id: 7002, provider_key: 'foo', default_service: true
+          expect { Service.delete_by_id(service.id) }.to_not raise_error
+        end
+
         it 'raises an exception if you try to delete a default service' do
           expect { Service.delete_by_id(service.id) }.to raise_error(ServiceIsDefaultService)
 


### PR DESCRIPTION
When a Service is deleted, all of its errors should be deleted.