### PR TITLE
When a Service is deleted, its latest transactions should be deleted

### DIFF
--- a/lib/3scale/backend/service.rb
+++ b/lib/3scale/backend/service.rb
@@ -220,6 +220,7 @@ module ThreeScale
         delete_from_lists
         delete_attributes
         ErrorStorage.delete_all(id)
+        TransactionStorage.delete_all(id)
       end
 
       def to_hash

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -408,7 +408,26 @@ module ThreeScale
             .to change { ErrorStorage.count(service.id) }.from(2).to(0)
         end
 
-        it 'does not raise an exception when deleting a service without errors' do
+        it 'deletes all service latest transactions' do
+          Service.save! id: 7002, provider_key: 'foo', default_service: true
+          transactions = []
+          transactions << ThreeScale::Backend::Transaction.new(
+            service_id: service.id,
+            application_id: 'test_application1_id',
+            usage: 'test_usage_1',
+            timestamp: Time.now)
+          transactions << ThreeScale::Backend::Transaction.new(
+              service_id: service.id,
+              application_id: 'test_application2_id',
+              usage: 'test_usage_2',
+              timestamp: Time.now)
+          TransactionStorage.store_all(transactions)
+
+          expect { Service.delete_by_id(service.id) }
+            .to change { TransactionStorage.list(service.id).size }.from(2).to(0)
+        end
+
+        it 'does not raise an exception when deleting a service without errors or latest transactions' do
           Service.save! id: 7002, provider_key: 'foo', default_service: true
           expect { Service.delete_by_id(service.id) }.to_not raise_error
         end


### PR DESCRIPTION
For all the Services, the latest transactions that have been processed
are stored in Redis. The purpose of this is to be queried by other
components that use apisonator to show the latest traffic of the
service. Once a service is removed all the stored transactions
should be removed.