### PR TITLE
Gemfiles: update rubyzip indirect dependency to fix CVE-2018-1000544

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     scientist (1.0.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -245,4 +245,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -146,7 +146,7 @@ GEM
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -223,4 +223,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/licenses.xml
+++ b/licenses.xml
@@ -103,7 +103,7 @@
         </dependency>
             <dependency>
           <packageName>bundler</packageName>
-          <version>1.16.2</version>
+          <version>1.16.6</version>
           <licenses>
                           <license>
                 <name>MIT</name>
@@ -699,7 +699,7 @@
         </dependency>
             <dependency>
           <packageName>rubyzip</packageName>
-          <version>1.2.1</version>
+          <version>1.2.2</version>
           <licenses>
                           <license>
                 <name>Simplified BSD</name>


### PR DESCRIPTION
Upgrade rubyzip dependency to fix CVE-2018-1000544.

https://access.redhat.com/security/cve/cve-2018-1000544