### PR TITLE
Rakefile: Add tasks to check redis storage and queue storage connection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,9 @@ require '3scale/tasks/helpers'
 
 include ThreeScale::Tasks::Helpers
 
+load 'lib/3scale/tasks/connectivity.rake'
+
+
 if Environment.saas?
   require '3scale/backend/logging/external'
 

--- a/lib/3scale/tasks/connectivity.rake
+++ b/lib/3scale/tasks/connectivity.rake
@@ -1,0 +1,31 @@
+namespace :connectivity do
+  desc 'Check connectivity of Redis Storage'
+  task :redis_storage_check do
+    begin
+      redis_instance = ThreeScale::Backend::Storage.instance
+      redis_instance.ping
+    rescue => e
+      warn "Error connecting to Redis Storage: #{e}"
+      exit(false)
+    else
+      puts "Connection to Redis Storage (#{redis_instance.id}) performed successfully"
+    end
+  end
+
+  desc 'Check connectivity of Redis Queue Storage'
+  task :redis_storage_queue_check do
+    begin
+      redis_instance = ThreeScale::Backend::QueueStorage.connection(
+        ThreeScale::Backend.environment,
+        ThreeScale::Backend.configuration,
+      )
+      redis_instance.ping
+    rescue => e
+      warn "Error connecting to Redis Queue Storage: #{e}"
+      exit(false)
+    else
+      puts "Connection to Redis Queue Storage (#{redis_instance.id}) performed successfully"
+    end
+  end
+
+end


### PR DESCRIPTION
Performed tests in apisonator local development environment:

```
[ruby@apisonator-dev apisonator]$ CONFIG_FILE=openshift/3scale_backend.conf CONFIG_REDIS_PROXY=127.0.0.1:6379 bundle exec rake connectivity:redis_storage_check
[ruby@apisonator-dev apisonator]$ echo $?
0
[ruby@apisonator-dev apisonator]$ CONFIG_FILE=openshift/3scale_backend.conf CONFIG_REDIS_PROXY=127.0.0.1:6380 bundle exec rake connectivity:redis_storage_check
Error connecting to Redis Storage: Error connecting to Redis on 127.0.0.1:6380 (Errno::ECONNREFUSED)
[ruby@apisonator-dev apisonator]$ echo $?
1
[ruby@apisonator-dev apisonator]$ CONFIG_FILE=openshift/3scale_backend.conf CONFIG_QUEUES_MASTER_NAME=127.0.0.1:6379 bundle exec rake connectivity:redis_storage_queue_check
[ruby@apisonator-dev apisonator]$ echo $?
0
[ruby@apisonator-dev apisonator]$ CONFIG_FILE=openshift/3scale_backend.conf CONFIG_QUEUES_MASTER_NAME=127.0.0.1:6380 bundle exec rake connectivity:redis_storage_queue_check
Error connecting to Redis Queue Storage: Error connecting to Redis on 127.0.0.1:6380 (Errno::ECONNREFUSED)
[ruby@apisonator-dev apisonator]$ echo $?
1
```