### PR TITLE
Rakefile: fix typo on .dependency_decisions.yml file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -229,7 +229,7 @@ if Environment.saas?
           $VERBOSE = prev_verbose_lvl
           LicenseFinder::CLI::Main.start [
             'report',
-            "--decisions-file=#{File.dirname(__FILE__)}/.dependency-decisions.yml",
+            "--decisions-file=#{File.dirname(__FILE__)}/.dependency_decisions.yml",
             '--format=xml'
           ]
         end


### PR DESCRIPTION
Does not make any difference (nowadays) on generated xml report, but still good to have fixed