### PR TITLE
Dockerfile.ci: rubygems-update fix to 2.7.8

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -143,7 +143,7 @@ RUN mkdir -p ~/.local/bin \
        "RUBY_BUILD_SKIP_MIRROR=1 rbenv install -s \"\${RBENV_VERSION:-}\"\n" \
        "    rbenv rehash\n" \
        "    rbenv shell \"\${RBENV_VERSION:-}\" 2> /dev/null\n" \
-       "    gem update --system\n" \
+       "    gem update --system '2.7.8'\n" \
        "  fi\n" \
        "}\n\n" \
        "if [[ \"\${BASH_SOURCE[0]}\" = \"\${0}\" ]]; then\n" \


### PR DESCRIPTION
Fix rubygems-update to `2.7.8`

rubygems-update ~> 3.0 requires ruby >= 2.3. Breaks our tests for ruby 2.2

```
Step 53/63 : RUN sudo chown -R "${USER_NAME}": /tmp/apisonator     && cd /tmp/apisonator     && rbenv_update_env

 ---> Running in 8586b5cf70e6


Downloading ruby-2.2.4.tar.bz2...

-> https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2

Installing ruby-2.2.4...


WARNING: ruby-2.2.4 is nearing its end of life.

It only receives critical security updates, no bug fixes.

Installed ruby-2.2.4 to /home/ruby/.rbenv/versions/2.2.4


ERROR:  Error installing rubygems-update:

    rubygems-update requires Ruby version >= 2.3.0.

ERROR:  While executing gem ... (NoMethodError)

    undefined method `version' for nil:NilClass

Updating rubygems-update

The command '/bin/sh -c sudo chown -R "${USER_NAME}": /tmp/apisonator     && cd /tmp/apisonator     && rbenv_update_env' returned a non-zero code: 1
```