### PR TITLE
Update Nokogiri to v1.9.1

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -17,7 +17,7 @@ end
 group :test do
   gem 'benchmark-ips', '~> 2.7.2'
   gem 'mocha',         '~> 1.3'
-  gem 'nokogiri',      '~> 1.8.3'
+  gem 'nokogiri',      '~> 1.9.1'
   gem 'pkg-config',    '~> 1.1.7'
   gem 'rack-test',     '~> 0.8.2'
   gem 'resque_unit',   '~> 0.4.4', source: 'https://rubygems.org'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       xml-simple
     metaclass (0.0.4)
     method_source (0.9.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.10.3)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
@@ -110,8 +110,8 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nokogiri (1.8.3)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.9.1)
+      mini_portile2 (~> 2.4.0)
     pg (0.20.0)
     pkg-config (1.1.9)
     power_assert (1.1.1)
@@ -217,7 +217,7 @@ DEPENDENCIES
   license_finder (~> 3.0.4)
   license_finder_xml_reporter!
   mocha (~> 1.3)
-  nokogiri (~> 1.8.3)
+  nokogiri (~> 1.9.1)
   pg (= 0.20.0)
   pkg-config (~> 1.1.7)
   pry (~> 0.11.3)

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -85,7 +85,7 @@ GEM
       xml-simple
     metaclass (0.0.4)
     method_source (0.9.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.10.3)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
@@ -99,8 +99,8 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nokogiri (1.8.3)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.9.1)
+      mini_portile2 (~> 2.4.0)
     pkg-config (1.1.9)
     power_assert (1.1.1)
     pry (0.11.3)
@@ -199,7 +199,7 @@ DEPENDENCIES
   license_finder (~> 3.0.4)
   license_finder_xml_reporter!
   mocha (~> 1.3)
-  nokogiri (~> 1.8.3)
+  nokogiri (~> 1.9.1)
   pkg-config (~> 1.1.7)
   pry (~> 0.11.3)
   pry-byebug (~> 3.5.1)


### PR DESCRIPTION
There's a CVE that affects the version that we are using:

```
CVE-2018-14404 More information
moderate severity
Vulnerable versions: < 1.8.5
Patched version: 1.8.5
A NULL pointer dereference vulnerability exists in the xpath.c:xmlXPathCompOpEval() function of libxml2 through 2.9.8 when parsing an invalid XPath expression in the XPATH_OP_AND or XPATH_OP_OR case. Applications processing untrusted XSL format inputs with the use of the libxml2 library may be vulnerable to a denial of service attack due to a crash of the application.
```

I can't update to the latest version available because it no longer supports Ruby 2.2.