### PR TITLE
extensions/time: make to_compact_s 4x faster

### DIFF
--- a/bench/extensions/to_compact_s_bench.rb
+++ b/bench/extensions/to_compact_s_bench.rb
@@ -1,0 +1,60 @@
+require 'benchmark/ips'
+
+module ToCompactSBenchmark
+  module Other
+    def old_to_compact_s
+      strftime('%Y%m%d%H%M%S').sub(/0{0,6}$/, '')
+    end
+
+    MODS = 61.times.map do |i|
+      i % 10
+    end.freeze
+    private_constant :MODS
+
+    DIVS = 61.times.map do |i|
+      i / 10
+    end.freeze
+    private_constant :DIVS
+
+    def new_to_compact_s
+      s = year * 10000 +  month * 100 + day
+      if sec != 0
+        s = s * 100000 + hour * 1000 + min * 10
+        MODS[sec] == 0 ? s + DIVS[sec] : s * 10 + sec
+      elsif min != 0
+        s = s * 1000 + hour * 10
+        MODS[min] == 0 ? s + DIVS[min] : s * 10 + min
+      elsif hour != 0
+        s = s * 10
+        MODS[hour] == 0 ? s + DIVS[hour] : s * 10 + hour
+      else
+        s
+      end.to_s
+    end
+  end
+
+  Time.send :include, Other
+
+  def self.run
+    tssec = Time.utc(2019, 02, 28, 0, 0, 1)
+    tsmin = Time.utc(2019, 02, 28, 0, 1, 0)
+    tshour = Time.utc(2019, 02, 28, 1, 0, 0)
+    tsday = Time.utc(2019, 02, 28, 0, 0, 0)
+
+    [tssec, tsmin, tshour, tsday].each_with_index do |ts, i|
+      puts "#{i+1}. Comparison for #{ts}"
+      Benchmark.ips do |x|
+        x.report "old_to_compact_s #{ts.inspect}" do
+          ts.old_to_compact_s
+        end
+        x.report "new_to_compact_s #{ts.inspect}" do
+          ts.new_to_compact_s
+        end
+        x.compare!
+      end
+
+    end
+  end
+end
+
+ToCompactSBenchmark.run

--- a/lib/3scale/backend/extensions/time.rb
+++ b/lib/3scale/backend/extensions/time.rb
@@ -32,8 +32,32 @@ module ThreeScale
       #
       # That behavior does not happen with days ending with a 0:
       # Time.utc(2016, 1, 20, 0, 0, 0).to_compact_s # "20160120"
+
+      # Leap seconds would map to 60, so include it.
+      MODS = 61.times.map do |i|
+        i % 10
+      end.freeze
+      private_constant :MODS
+
+      DIVS = 61.times.map do |i|
+        i / 10
+      end.freeze
+      private_constant :DIVS
+
       def to_compact_s
-        strftime('%Y%m%d%H%M%S').sub(/0{0,6}$/, '')
+        s = year * 10000 +  month * 100 + day
+        if sec != 0
+          s = s * 100000 + hour * 1000 + min * 10
+          MODS[sec] == 0 ? s + DIVS[sec] : s * 10 + sec
+        elsif min != 0
+          s = s * 1000 + hour * 10
+          MODS[min] == 0 ? s + DIVS[min] : s * 10 + min
+        elsif hour != 0
+          s = s * 10
+          MODS[hour] == 0 ? s + DIVS[hour] : s * 10 + hour
+        else
+          s
+        end.to_s
       end
 
       def to_not_compact_s

--- a/lib/3scale/backend/extensions/time.rb
+++ b/lib/3scale/backend/extensions/time.rb
@@ -44,6 +44,11 @@ module ThreeScale
       end.freeze
       private_constant :DIVS
 
+      # This function is equivalent to:
+      # strftime('%Y%m%d%H%M%S').sub(/0{0,6}$/, '').
+      #
+      # When profiling, we found that this method was one of the ones which
+      # consumed more CPU time so we decided to optimize it.
       def to_compact_s
         s = year * 10000 +  month * 100 + day
         if sec != 0


### PR DESCRIPTION
`Time#to_compact_s` appears as a hot method in profiling and this should improve its total CPU time.