### PR TITLE
Fix/response code processing

### DIFF
--- a/lib/3scale/backend/stats/aggregators/response_code.rb
+++ b/lib/3scale/backend/stats/aggregators/response_code.rb
@@ -36,13 +36,19 @@ module ThreeScale
             end
 
             def values_to_inc(response_code)
-              keys = [Stats::CodesCommons.get_http_code_group(response_code)]
-              keys << response_code.to_s if tracked_code?(response_code)
-              keys
+              group_code = Stats::CodesCommons.get_http_code_group(response_code)
+              [].tap do |keys|
+                keys << group_code if tracked_group_code?(group_code)
+                keys << response_code.to_s if tracked_code?(response_code)
+              end
             end
 
             def tracked_code?(code)
               Stats::CodesCommons::TRACKED_CODES.include?(code)
+            end
+
+            def tracked_group_code?(group_code)
+              Stats::CodesCommons::TRACKED_CODE_GROUPS.include?(group_code)
             end
           end
         end

--- a/lib/3scale/backend/stats/codes_commons.rb
+++ b/lib/3scale/backend/stats/codes_commons.rb
@@ -3,13 +3,10 @@ module ThreeScale
     module Stats
       module CodesCommons
         TRACKED_CODES = [200, 404, 403, 500, 503].freeze
-
-        HTTP_CODE_GROUPS_MAP = TRACKED_CODES.each_with_object({}) do |code, hsh|
-          hsh[code / 100] = "#{code / 100}XX"
-        end
+        TRACKED_CODE_GROUPS = ['2XX'.freeze, '4XX'.freeze, '5XX'.freeze].freeze
 
         def self.get_http_code_group(http_code)
-          HTTP_CODE_GROUPS_MAP.fetch(http_code / 100)
+          "#{http_code / 100}XX"
         end
       end
     end

--- a/lib/3scale/backend/stats/key_generator.rb
+++ b/lib/3scale/backend/stats/key_generator.rb
@@ -31,7 +31,7 @@ module ThreeScale
         end
 
         def response_codes
-          CodesCommons::TRACKED_CODES + CodesCommons::HTTP_CODE_GROUPS_MAP.values
+          CodesCommons::TRACKED_CODES + CodesCommons::TRACKED_CODE_GROUPS
         end
 
         def response_code_service_keys

--- a/spec/unit/stats/aggregators/response_code_spec.rb
+++ b/spec/unit/stats/aggregators/response_code_spec.rb
@@ -41,9 +41,17 @@ module ThreeScale
               transaction.response_code = "4xx9"
               expect(aggregator.aggregate(transaction).length).to eq(0)
             end
+            
+            it 'returns empty for 100 response_codes' do
+              transaction.response_code = "100"
+              expect(aggregator.aggregate(transaction).length).to eq(0)
+            end
 
+            it 'returns empty for 304 response_codes' do
+              transaction.response_code = "304"
+              expect(aggregator.aggregate(transaction).length).to eq(0)
+            end
           end
-
         end
       end
     end


### PR DESCRIPTION
* Fix https://github.com/3scale/apisonator/pull/78#issuecomment-469279602
Do not raise an exception when a user reports a response code that Apisonator does not track, for example, 304.

* Do not account for untracked http response codes, currently, for example 304