### PR TITLE
Non-blocking Redis calls: optimize pipelines by flushing just once

### DIFF
--- a/lib/3scale/backend/storage_async.rb
+++ b/lib/3scale/backend/storage_async.rb
@@ -1,3 +1,3 @@
-require '3scale/backend/storage_async/async_redis'
 require '3scale/backend/storage_async/client'
 require '3scale/backend/storage_async/pipeline'
+require '3scale/backend/storage_async/async_redis'

--- a/lib/3scale/backend/storage_async/async_redis.rb
+++ b/lib/3scale/backend/storage_async/async_redis.rb
@@ -8,10 +8,40 @@ module Async
       def call_pipeline(commands)
         @pool.acquire do |connection|
           commands.each do |command|
-            connection.write_request(command)
+            connection.write_request_without_flush(command)
           end
 
+          connection.flush
+
           commands.size.times.map { connection.read_response }
+        end
+      end
+    end
+  end
+end
+
+module Async
+  module Redis
+    module Protocol
+      class RESP
+
+        # This is exactly the same as #write_request but without flushing at
+        # the end. It leaves the responsibility of flushing to the caller.
+        # This method is useful for pipelining because instead of flushing
+        # once per command, we want to flush just once for the whole pipeline
+        # for performance reasons.
+        def write_request_without_flush(arguments)
+          write_lines("*#{arguments.count}")
+
+          arguments.each do |argument|
+            string = argument.to_s
+
+            write_lines("$#{string.bytesize}", string)
+          end
+        end
+
+        def flush
+          @stream.flush
         end
       end
     end


### PR DESCRIPTION
This PR improves performance by making sure that we only call .write on the underlying socket just once per pipeline instead of per command.

Pipelines are not implemented in async-redis so we need to add the patch in our codebase. The idea is to contribute the pipelines functionality to the async-redis lib at some point.

Notice that the base branch of this PR is the `async` integration branch, not master.