### PR TITLE
Disable stats deletion endpoint

### DIFF
--- a/app/api/internal/stats.rb
+++ b/app/api/internal/stats.rb
@@ -6,6 +6,9 @@ module ThreeScale
           respond_with_404('service not found') unless Service.exists?(params[:service_id])
         end
 
+        # This is very slow and needs to be disabled until the performance
+        # issues are solved. In the meanwhile, the job will just return OK.
+=begin
         delete '' do |service_id|
           delete_stats_job_attrs = api_params Stats::DeleteJobDef
           delete_stats_job_attrs[:service_id] = service_id
@@ -18,6 +21,10 @@ module ThreeScale
           else
             { status: :to_be_deleted }.to_json
           end
+=end
+
+        delete '' do |service_id|
+          { status: :to_be_deleted }.to_json
         end
       end
     end

--- a/spec/acceptance/api/internal/stats_api_spec.rb
+++ b/spec/acceptance/api/internal/stats_api_spec.rb
@@ -38,6 +38,8 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
         ResqueSpec.reset!
       end
 
+      # The endpoint is disabled for now, just test that it returns 200
+=begin
       example_request 'Deleting stats' do
         expect(status).to eq 200
         expect(response_json['status']).to eq 'to_be_deleted'
@@ -46,6 +48,12 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
                                                                                  applications,
                                                                                  metrics, users,
                                                                                  from, to, nil)
+      end
+=end
+
+      example_request 'Deleting stats' do
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'to_be_deleted'
       end
     end
 
@@ -57,6 +65,7 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
       end
     end
 
+=begin
     context 'invalid param sent' do
       let(:from) { 'adfsadfasd' }
 
@@ -64,5 +73,6 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
         expect(status).to eq 400
       end
     end
+=end
   end
 end


### PR DESCRIPTION
This endpoint has performance issues that will need to be fixed before we enable it again.