### PR TITLE
[WIP] Fix/stats keygenerator lazy

### DIFF
--- a/app/api/internal/stats.rb
+++ b/app/api/internal/stats.rb
@@ -6,9 +6,6 @@ module ThreeScale
           respond_with_404('service not found') unless Service.exists?(params[:service_id])
         end
 
-        # This is very slow and needs to be disabled until the performance
-        # issues are solved. In the meanwhile, the job will just return OK.
-=begin
         delete '' do |service_id|
           delete_stats_job_attrs = api_params Stats::DeleteJobDef
           delete_stats_job_attrs[:service_id] = service_id
@@ -21,10 +18,6 @@ module ThreeScale
           else
             { status: :to_be_deleted }.to_json
           end
-=end
-
-        delete '' do |service_id|
-          { status: :to_be_deleted }.to_json
         end
       end
     end

--- a/lib/3scale/backend/stats/key_generator.rb
+++ b/lib/3scale/backend/stats/key_generator.rb
@@ -14,19 +14,29 @@ module ThreeScale
         end
 
         def keys
-          response_code_service_keys +
-            response_code_application_keys +
-            response_code_user_keys +
-            usage_service_keys +
-            usage_application_keys +
-            usage_user_keys
+          Enumerator.new do |y|
+            response_code_service_keys.each { |e| y << e }
+            response_code_application_keys.each { |e| y << e }
+            response_code_user_keys.each { |e| y << e }
+            usage_service_keys.each { |e| y << e }
+            usage_application_keys.each { |e| y << e }
+            usage_user_keys.each { |e| y << e }
+          end
         end
 
         private
 
+        def period_range(granularity)
+          Period[granularity].new(Time.at(from))..Period[granularity].new(Time.at(to))
+        end
+
         def periods(granularities)
-          granularities.flat_map do |granularity|
-            (Period[granularity].new(Time.at(from))..Period[granularity].new(Time.at(to))).to_a
+          Enumerator.new do |y|
+            granularities.each do |gr|
+              period_range(gr).each do |period|
+                y << period
+              end
+            end
           end
         end
 
@@ -35,57 +45,69 @@ module ThreeScale
         end
 
         def response_code_service_keys
-          periods(PeriodCommons::PERMANENT_SERVICE_GRANULARITIES).flat_map do |period|
-            response_codes.flat_map do |response_code|
-              Keys.service_response_code_value_key(service_id, response_code, period)
+          Enumerator.new do |y|
+            periods(PeriodCommons::PERMANENT_SERVICE_GRANULARITIES).each do |period|
+              response_codes.each do |response_code|
+                y << Keys.service_response_code_value_key(service_id, response_code, period)
+              end
             end
           end
         end
 
         def response_code_application_keys
-          periods(PeriodCommons::PERMANENT_EXPANDED_GRANULARITIES).flat_map do |period|
-            response_codes.flat_map do |response_code|
-              applications.flat_map do |application|
-                Keys.application_response_code_value_key(service_id, application,
-                                                         response_code, period)
+          Enumerator.new do |y|
+            periods(PeriodCommons::PERMANENT_EXPANDED_GRANULARITIES).each do |period|
+              response_codes.each do |response_code|
+                applications.each do |application|
+                  y << Keys.application_response_code_value_key(service_id, application,
+                                                                response_code, period)
+                end
               end
             end
           end
         end
 
         def response_code_user_keys
-          periods(PeriodCommons::PERMANENT_EXPANDED_GRANULARITIES).flat_map do |period|
-            response_codes.flat_map do |response_code|
-              users.flat_map do |user|
-                Keys.user_response_code_value_key(service_id, user, response_code, period)
+          Enumerator.new do |y|
+            periods(PeriodCommons::PERMANENT_EXPANDED_GRANULARITIES).each do |period|
+              response_codes.each do |response_code|
+                users.each do |user|
+                  y << Keys.user_response_code_value_key(service_id, user, response_code, period)
+                end
               end
             end
           end
         end
 
         def usage_service_keys
-          periods(PeriodCommons::PERMANENT_SERVICE_GRANULARITIES).flat_map do |period|
-            metrics.flat_map do |metric|
-              Keys.service_usage_value_key(service_id, metric, period)
+          Enumerator.new do |y|
+            periods(PeriodCommons::PERMANENT_SERVICE_GRANULARITIES).each do |period|
+              metrics.each do |metric|
+                y << Keys.service_usage_value_key(service_id, metric, period)
+              end
             end
           end
         end
 
         def usage_application_keys
-          periods(PeriodCommons::PERMANENT_EXPANDED_GRANULARITIES).flat_map do |period|
-            metrics.flat_map do |metric|
-              applications.flat_map do |application|
-                Keys.application_usage_value_key(service_id, application, metric, period)
+          Enumerator.new do |y|
+            periods(PeriodCommons::PERMANENT_EXPANDED_GRANULARITIES).each do |period|
+              metrics.each do |metric|
+                applications.each do |application|
+                  y << Keys.application_usage_value_key(service_id, application, metric, period)
+                end
               end
             end
           end
         end
 
         def usage_user_keys
-          periods(PeriodCommons::PERMANENT_EXPANDED_GRANULARITIES).flat_map do |period|
-            users.flat_map do |user|
-              metrics.flat_map do |metric|
-                Keys.user_usage_value_key(service_id, user, metric, period)
+          Enumerator.new do |y|
+            periods(PeriodCommons::PERMANENT_EXPANDED_GRANULARITIES).each do |period|
+              users.each do |user|
+                metrics.each do |metric|
+                  y << Keys.user_usage_value_key(service_id, user, metric, period)
+                end
               end
             end
           end

--- a/spec/acceptance/api/internal/stats_api_spec.rb
+++ b/spec/acceptance/api/internal/stats_api_spec.rb
@@ -38,8 +38,6 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
         ResqueSpec.reset!
       end
 
-      # The endpoint is disabled for now, just test that it returns 200
-=begin
       example_request 'Deleting stats' do
         expect(status).to eq 200
         expect(response_json['status']).to eq 'to_be_deleted'
@@ -48,12 +46,6 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
                                                                                  applications,
                                                                                  metrics, users,
                                                                                  from, to, nil)
-      end
-=end
-
-      example_request 'Deleting stats' do
-        expect(status).to eq 200
-        expect(response_json['status']).to eq 'to_be_deleted'
       end
     end
 
@@ -65,7 +57,6 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
       end
     end
 
-=begin
     context 'invalid param sent' do
       let(:from) { 'adfsadfasd' }
 
@@ -73,6 +64,5 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
         expect(status).to eq 400
       end
     end
-=end
   end
 end

--- a/spec/unit/stats/key_generator_spec.rb
+++ b/spec/unit/stats/key_generator_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ThreeScale::Backend::Stats::KeyGenerator do
     end
   end
 
-  subject { described_class.new(job_params).keys }
+  subject { described_class.new(job_params).keys.to_a }
 
   context 'responsecode_service keys' do
     it 'include expected keys' do


### PR DESCRIPTION
**Currently**
`PartitionGeneratorJob` takes long time to generate ~12M stats keys and produce ~12k `PartitionEraserJob`. This causes the job queue to increase in size and memory usage alarm fires.

There are three main aspects causing the mentioned issues:
* High memory usage requirement
* Long time taken to generate keys. It takes ~400 secs to generate 12M keys.
* Long time taken to enqueue 12K new jobs. ~ 16secs

Stats deletion design strategy must be changed after seeing results. New requirements:
* Worker jobs must take, at maximum, few secs to finish their job. More is unacceptable and can affect other jobs.

Closing this PR because new design strategy is needed. `PartitionGenerator` and `PartitionEraser` job design does not work