### PR TITLE
Non-blocking Redis calls: add an async worker

### DIFF
--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -55,6 +55,18 @@ module ThreeScale
       config.add_section(:oauth, :max_token_size)
       config.add_section(:master, :metrics)
 
+      config.add_section(
+          :async_worker,
+
+          # Max number of jobs in the reactor
+          :max_concurrent_jobs,
+          # Max number of jobs in memory pending to be added to the reactor
+          :max_pending_jobs,
+          # Seconds to wait before fetching more jobs when the number of jobs
+          # in memory has reached max_pending_jobs.
+          :seconds_before_fetching_more
+      )
+
       # Configure nested fields
       master_metrics = [:transactions, :transactions_authorize]
       config.master.metrics = Struct.new(*master_metrics).new

--- a/lib/3scale/backend/job_fetcher.rb
+++ b/lib/3scale/backend/job_fetcher.rb
@@ -1,0 +1,49 @@
+module ThreeScale
+  module Backend
+    class JobFetcher
+      include Resque::Helpers
+
+      # the order is relevant
+      QUEUES = [:priority, :main, :stats].freeze
+      private_constant :QUEUES
+
+      REDIS_TIMEOUT = 60
+      private_constant :REDIS_TIMEOUT
+
+      # The default redis_client is the one defined in Resque::Helpers
+      def initialize(redis_client: redis, fetch_timeout: REDIS_TIMEOUT)
+        @redis = redis_client
+        @fetch_timeout = fetch_timeout
+        @queues ||= QUEUES.map { |q| "queue:#{q}" }
+      end
+
+      def fetch
+        encoded_job = @redis.blpop(*@queues, timeout: @fetch_timeout)
+
+        return nil if encoded_job.nil? || encoded_job.empty?
+
+        begin
+          # Resque::Job.new accepts a queue name as a param. It is very
+          # important to set here the same name as the one we set when calling
+          # Resque.enqueue. Resque.enqueue uses the @queue ivar in
+          # BackgroundJob classes as the name of the queue, and then, it stores
+          # the job in a queue called resque:queue:_@queue_. 'resque:' is the
+          # namespace and 'queue:' is added automatically. That's why we need
+          # to call blpop on 'queue:#{q}' above. However, when creating the job
+          # we cannot set 'queue:#{q}' as the name. Otherwise, if it fails and
+          # it is re-queued, it will end up in resque:queue:queue:_@queue_
+          # instead of resque:queue:_@queue_.
+          encoded_job[0].sub!('queue:', '')
+          Resque::Job.new(encoded_job[0],
+                          Yajl::Parser.parse(encoded_job[1], check_utf8: false))
+        rescue Exception => e
+          # I think that the only exception that can be raised here is
+          # Yajl::ParseError. However, this is a critical part of the code so
+          # we will capture all of them just to be safe.
+          Worker.logger.notify(e)
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale/backend/storage_async/client.rb
+++ b/lib/3scale/backend/storage_async/client.rb
@@ -120,6 +120,18 @@ module ThreeScale
           end
         end
 
+        def blpop(*args)
+          call_args = ['BLPOP'] + args
+
+          # redis-rb accepts a Hash as last arg that can contain :timeout.
+          if call_args.last.is_a? Hash
+            timeout = call_args.pop[:timeout]
+            call_args << timeout
+          end
+
+          @redis_async.call(*call_args.flatten)
+        end
+
         def set(key, val, opts = {})
           args = ['SET', key, val]
 

--- a/lib/3scale/backend/worker.rb
+++ b/lib/3scale/backend/worker.rb
@@ -1,6 +1,7 @@
 require '3scale/backend/configuration'
 require '3scale/backend/logging/worker'
 require '3scale/backend/logging/external'
+require '3scale/backend/job_fetcher'
 
 module ThreeScale
   module Backend
@@ -12,10 +13,6 @@ module ThreeScale
     class Worker
       include Resque::Helpers
       include Configurable
-
-      # the order is relevant
-      QUEUES = [:priority, :main, :stats]
-      REDIS_TIMEOUT = 60
 
       def initialize(options)
         trap('TERM') { shutdown }
@@ -40,12 +37,14 @@ module ThreeScale
       end
 
       def work
+        job_fetcher = JobFetcher.new
+
         register_worker
 
         loop do
           break if @shutdown
 
-          job = reserve
+          job = job_fetcher.fetch
           perform(job) if job
 
           break if one_off?
@@ -59,7 +58,7 @@ module ThreeScale
       end
 
       def to_s
-        @to_s ||= "#{hostname}:#{Process.pid}:#{QUEUES.join(',')}"
+        @to_s ||= "#{hostname}:#{Process.pid}"
       end
 
       def one_off?
@@ -67,35 +66,6 @@ module ThreeScale
       end
 
       private
-
-      def reserve
-        @queues ||= QUEUES.map { |q| "queue:#{q}" }
-        encoded_job = redis.blpop(*@queues, timeout: redis_timeout)
-
-        return nil if encoded_job.nil? || encoded_job.empty?
-
-        begin
-          # Resque::Job.new accepts a queue name as a param. It is very
-          # important to set here the same name as the one we set when calling
-          # Resque.enqueue. Resque.enqueue uses the @queue ivar in
-          # BackgroundJob classes as the name of the queue, and then, it stores
-          # the job in a queue called resque:queue:_@queue_. 'resque:' is the
-          # namespace and 'queue:' is added automatically. That's why we need
-          # to call blpop on 'queue:#{q}' above. However, when creating the job
-          # we cannot set 'queue:#{q}' as the name. Otherwise, if it fails and
-          # it is re-queued, it will end up in resque:queue:queue:_@queue_
-          # instead of resque:queue:_@queue_.
-          encoded_job[0].sub!('queue:', '')
-          Resque::Job.new(encoded_job[0],
-                          Yajl::Parser.parse(encoded_job[1], check_utf8: false))
-        rescue Exception => e
-          # I think that the only exception that can be raised here is
-          # Yajl::ParseError. However, this is a critical part of the code so
-          # we will capture all of them just to be safe.
-          Worker.logger.notify(e)
-          nil
-        end
-      end
 
       def perform(job)
         job.perform
@@ -109,10 +79,6 @@ module ThreeScale
 
       def unregister_worker
         redis.srem(:workers, self)
-      end
-
-      def redis_timeout
-        REDIS_TIMEOUT
       end
 
       def hostname

--- a/lib/3scale/backend/worker_async.rb
+++ b/lib/3scale/backend/worker_async.rb
@@ -1,0 +1,88 @@
+require 'async'
+require '3scale/backend/job_fetcher'
+
+module ThreeScale
+  module Backend
+    class WorkerAsync
+      include Backend::Worker
+      include Configurable
+
+      DEFAULT_MAX_CONCURRENT_JOBS = 20
+      private_constant :DEFAULT_MAX_CONCURRENT_JOBS
+
+      def initialize(options = {})
+        trap('TERM') { shutdown }
+        trap('INT')  { shutdown }
+
+        @one_off = options[:one_off]
+        @jobs = Queue.new # Thread-safe queue
+
+        @job_fetcher = options[:job_fetcher] || JobFetcher.new
+
+        @max_concurrent_jobs = configuration.async_worker.max_concurrent_jobs ||
+            DEFAULT_MAX_CONCURRENT_JOBS
+
+        @reactor = Async::Reactor.new
+      end
+
+      def work
+        if one_off?
+          Async { process_one }
+          return
+        end
+
+        Async { register_worker }
+
+        fetch_jobs_thread = start_thread_to_fetch_jobs
+
+        loop do
+          break if @shutdown
+          schedule_jobs
+          @reactor.run
+        end
+
+        fetch_jobs_thread.join
+
+        # Ensure that we do not leave any jobs in memory
+        @reactor.async { perform(@jobs.pop) } until @jobs.empty?
+        @reactor.run
+
+        Async { unregister_worker }
+      end
+
+      def shutdown
+        @job_fetcher.shutdown
+        @shutdown = true
+      end
+
+      private
+
+      def schedule_jobs
+        scheduled = 0
+
+        loop do
+          # unblocks when there are new jobs or when .close() is called
+          job = @jobs.pop
+
+          break if @shutdown
+
+          @reactor.async { perform(job) }
+          scheduled += 1
+
+          break if @jobs.empty? or scheduled >= @max_concurrent_jobs
+        end
+      end
+
+      def process_one
+        job = @job_fetcher.fetch
+        perform(job) if job
+      end
+
+      def start_thread_to_fetch_jobs
+        Thread.new do
+          Async { @job_fetcher.start(@jobs) }
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale/backend/worker_sync.rb
+++ b/lib/3scale/backend/worker_sync.rb
@@ -1,0 +1,32 @@
+require '3scale/backend/job_fetcher'
+
+module ThreeScale
+  module Backend
+    class WorkerSync
+      include Backend::Worker
+
+      def initialize(options = {})
+        trap('TERM') { shutdown }
+        trap('INT')  { shutdown }
+
+        @one_off = options[:one_off]
+        @job_fetcher = options[:job_fetcher] || JobFetcher.new
+      end
+
+      def work
+        register_worker
+
+        loop do
+          break if @shutdown
+
+          job = @job_fetcher.fetch
+          perform(job) if job
+
+          break if one_off?
+        end
+
+        unregister_worker
+      end
+    end
+  end
+end

--- a/spec/integration/worker_async_spec.rb
+++ b/spec/integration/worker_async_spec.rb
@@ -1,0 +1,79 @@
+require_relative '../spec_helper'
+require 'timecop'
+require 'daemons'
+require '3scale/backend/worker_async'
+
+module ThreeScale
+  module Backend
+    context 'when there are jobs enqueued' do
+      let(:provider_key) { 'a_provider_key' }
+      let(:service_id) { 'a_service_id' }
+      let(:app_id) { 'an_app_id' }
+      let(:metric_id) { 'a_metric_id' }
+      let(:metric_name) { 'hits' }
+
+      # We are going to enqueue report jobs. And those are enqueued the
+      # 'priority' queue.
+      let(:queue) { 'priority' }
+
+      let(:current_time) { Time.now }
+
+      before do
+        Service.save!(provider_key: provider_key, id: service_id)
+
+        Application.save(service_id: service_id,
+                         id: app_id,
+                         state: :active)
+
+        Metric.save(service_id: service_id,
+                    id: metric_id,
+                    name: metric_name)
+      end
+
+      it 'processes them' do
+        # For this test, we are going to perform a number of reports, and then,
+        # verify that the stats usage keys have been updated correctly.
+
+        n_reports = 10
+
+        without_resque_spec do
+          Timecop.freeze(current_time) do
+            n_reports.times do
+              Transactor.report(
+                  provider_key,
+                  service_id,
+                  0 => { app_id: app_id, usage: { metric_name => 1 } }
+              )
+            end
+          end
+        end
+
+        worker = Worker.new(async: true, job_fetcher: JobFetcher.new(fetch_timeout: 1))
+        worker_thread = Thread.new { worker.work }
+
+        stats_key = Stats::Keys.usage_value_key(
+            service_id, app_id, metric_id, Period[:day].new(current_time)
+        )
+
+        # We do not know when the worker thread will finish processing all the
+        # jobs. If it takes too much, we will assume that there has been some
+        # kind of error.
+        t_start = Time.now
+
+        while Storage.instance.get(stats_key).to_i < n_reports
+          if Time.now - t_start > 10
+            raise 'The worker is taking too much to process the jobs'
+          end
+
+          sleep(0.1)
+        end
+
+        worker.shutdown
+
+        worker_thread.join
+
+        expect(Storage.instance.get(stats_key).to_i).to eq n_reports
+      end
+    end
+  end
+end

--- a/spec/unit/job_fetcher_spec.rb
+++ b/spec/unit/job_fetcher_spec.rb
@@ -105,6 +105,37 @@ module ThreeScale
 
           job_fetcher.fetch
         end
+
+        context 'when there is an error getting elements from the queue' do
+          context 'and it is a connection error' do
+            let(:connection_errors) do
+              [Redis::BaseConnectionError,
+               Errno::ECONNREFUSED,
+               Errno::EPIPE,
+               Redis::CommandError.new('ERR Connection timed out')]
+            end
+
+            it 'raises RedisConnectionError' do
+              connection_errors.each do |conn_error|
+                allow(test_redis).to receive(:blpop).and_raise conn_error
+
+                expect { subject.fetch }.to raise_error JobFetcher::RedisConnectionError
+              end
+            end
+          end
+
+          context 'and it is not a connection error' do
+            let(:test_error) { RuntimeError.new('Some error') }
+
+            before do
+              allow(test_redis).to receive(:blpop).and_raise test_error
+            end
+
+            it 'propagates the exception' do
+              expect { subject.fetch }.to raise_error test_error
+            end
+          end
+        end
       end
 
       describe '#start' do

--- a/spec/unit/job_fetcher_spec.rb
+++ b/spec/unit/job_fetcher_spec.rb
@@ -1,14 +1,15 @@
+require '3scale/backend/job_fetcher'
+
 module ThreeScale
   module Backend
-    describe Worker do
-      # It is a private method, I know, but it was causing an important bug
-      # (workers crashing when decoding non-utf8 arguments for jobs), so it
-      # makes sense to test it.
-      describe '#reserve' do
-        subject { Worker.new(one_off: true) }
-
+    describe JobFetcher do
+      describe '#fetch' do
         let(:resque_queue) { 'queue:priority' }
         let(:job_queue) { resque_queue.sub('queue:', '') }
+
+        let(:test_redis) { double }
+
+        subject { JobFetcher.new(redis_client: test_redis) }
 
         context 'when the arguments of the job do not have encoding issues' do
           let(:enqueued_job) do
@@ -22,11 +23,11 @@ module ThreeScale
           let(:job_info) { [resque_queue, subject.encode(enqueued_job)] }
 
           before do
-            allow(subject.redis).to receive(:blpop).and_return(job_info)
+            allow(test_redis).to receive(:blpop).and_return(job_info)
           end
 
           it 'returns a job with the correct resque queue and payload' do
-            job = subject.send(:reserve)
+            job = subject.fetch
             expect(job.queue).to eq job_queue
             expect(job.payload).to eq enqueued_job
           end
@@ -42,33 +43,34 @@ module ThreeScale
           let(:job_info) { [resque_queue, enqueued_job] }
 
           before do
-            allow(subject.redis).to receive(:blpop).and_return(job_info)
+            allow(test_redis).to receive(:blpop).and_return(job_info)
           end
 
           it 'returns a job with the correct resque queue and payload' do
-            job = subject.send(:reserve)
+            job = subject.fetch
             expect(job.queue).to eq job_queue
             expect(job.payload).to eq JSON.parse(enqueued_job)
           end
 
           it 'does not replace the invalid chars of the job payload' do
-            expect(subject.send(:reserve).payload.valid_encoding?).to be false
+            job = subject.fetch
+            expect(job.payload.valid_encoding?).to be false
           end
         end
 
         context 'when the object we get from Resque queue is nil' do
-          before { allow(subject.redis).to receive(:blpop).and_return(nil) }
+          before { allow(test_redis).to receive(:blpop).and_return(nil) }
 
           it 'returns nil' do
-            expect(subject.send(:reserve)).to be nil
+            expect(subject.fetch).to be nil
           end
         end
 
         context 'when the object we get from the Resque queue is empty' do
-          before { allow(subject.redis).to receive(:blpop).and_return([]) }
+          before { allow(test_redis).to receive(:blpop).and_return([]) }
 
           it 'returns nil' do
-            expect(subject.send(:reserve)).to be nil
+            expect(subject.fetch).to be nil
           end
         end
 
@@ -76,18 +78,32 @@ module ThreeScale
           let(:invalid_enqueued_job) { [resque_queue, '{}}'] }
 
           before do
-            allow(subject.redis).to receive(:blpop).and_return(invalid_enqueued_job)
-            allow(described_class.logger).to receive(:notify)
+            Worker.new # To make sure the workers logging is configured
+            allow(test_redis).to receive(:blpop).and_return(invalid_enqueued_job)
+            allow(Worker.logger).to receive(:notify)
           end
 
           it 'returns nil' do
-            expect(subject.send(:reserve)).to be nil
+            expect(subject.fetch).to be nil
           end
 
           it 'notifies the logger' do
-            expect(described_class.logger).to receive(:notify)
-            subject.send :reserve
+            expect(Worker.logger).to receive(:notify)
+            subject.fetch
           end
+        end
+
+        it 'fetches jobs from queues in the order defined (priority > main > stats)' do
+          fetch_timeout = 1
+          job_fetcher = JobFetcher.new(
+              redis_client: test_redis, fetch_timeout: fetch_timeout
+          )
+
+          expect(test_redis)
+              .to receive(:blpop)
+              .with('queue:priority', 'queue:main', 'queue:stats', timeout: fetch_timeout)
+
+          job_fetcher.fetch
         end
       end
     end

--- a/spec/unit/job_fetcher_spec.rb
+++ b/spec/unit/job_fetcher_spec.rb
@@ -106,6 +106,115 @@ module ThreeScale
           job_fetcher.fetch
         end
       end
+
+      describe '#start' do
+        let(:resque_queue) { 'queue:priority' }
+        let(:job_queue) { resque_queue.sub('queue:', '') }
+
+        let(:test_redis) { double }
+
+        subject { JobFetcher.new(redis_client: test_redis) }
+
+        describe 'when the max num of jobs in the local queue is not reached' do
+          let(:jobs) do
+            [
+              [job_queue, subject.encode(BackgroundJob.new)],
+              [job_queue, subject.encode(BackgroundJob.new)],
+              nil
+            ]
+          end
+
+          before do
+            # This returns the 2 jobs in the 2 first calls, and nil for any
+            # call after that.
+            allow(test_redis).to receive(:blpop).and_return(*jobs)
+          end
+
+          it 'fetches jobs and puts them in a local queue' do
+            queue = Queue.new
+            t = Thread.new { subject.start(queue) }
+
+            (jobs.size - 1).times do |i|
+              job = queue.pop
+              expect(job.queue).to eq jobs[i].first
+              expect(job.payload).to eq JSON.parse(jobs[i].last)
+            end
+
+            subject.shutdown
+            t.join
+          end
+        end
+
+        describe 'when it reaches the maximum num of jobs in the local queue' do
+          let(:original_async_worker_config) do
+            ThreeScale::Backend.configuration.async_worker
+          end
+
+          let(:max_pending_jobs) { 10 }
+          let(:wait_before_trying_to_fetch_more) { 0.1/100 }
+
+          let(:job) do
+            [job_queue, subject.encode(BackgroundJob.new)]
+          end
+
+          let(:queue) { Queue.new }
+
+          before do
+            allow(test_redis).to receive(:blpop).and_return(job)
+
+            ThreeScale::Backend.configuration.async_worker.max_pending_jobs =
+                max_pending_jobs
+
+            ThreeScale::Backend.configuration.async_worker.seconds_before_fetching_more =
+                wait_before_trying_to_fetch_more
+          end
+
+          after do
+            ThreeScale::Backend.configuration.async_worker = original_async_worker_config
+          end
+
+          it 'does not store more jobs than the max defined' do
+            # In this test, there is no one popping jobs from the queue, so
+            # the max capacity will be reached
+
+            # Need to re-instantiate so it picks the modified config values
+            subject = JobFetcher.new(redis_client: test_redis)
+            allow(subject).to receive(:sleep)
+
+            t = Thread.new { subject.start(queue) }
+
+            sleep(0.1) while queue.size < max_pending_jobs
+            sleep(0.1) # Give it more time to try to add more jobs to the queue
+
+            subject.shutdown
+            t.join
+
+            expect(queue.size).to eq max_pending_jobs
+          end
+
+          it 'sleeps before trying to fetch more' do
+            # In this test, there is no one popping jobs from the queue, so
+            # the max capacity will be reached
+
+            # Need to re-instantiate so it picks the modified config values
+            subject = JobFetcher.new(redis_client: test_redis)
+            allow(subject).to receive(:sleep)
+
+            t = Thread.new { subject.start(queue) }
+
+            sleep(0.1) while queue.size < max_pending_jobs
+            sleep(0.1) # Give it more time to try to add more jobs to the queue
+
+            subject.shutdown
+            t.join
+
+            expect(subject)
+                .to have_received(:sleep)
+                .with(wait_before_trying_to_fetch_more)
+                .at_least(1).times
+          end
+        end
+      end
     end
   end
 end

--- a/spec/unit/worker_async_spec.rb
+++ b/spec/unit/worker_async_spec.rb
@@ -1,0 +1,49 @@
+require '3scale/backend/worker_async'
+
+module ThreeScale
+  module Backend
+    describe WorkerAsync do
+      describe '#work' do
+        let(:job_fetcher) { instance_double('JobFetcher') }
+
+        describe 'when the one_off option is enabled' do
+          subject do
+            WorkerAsync.new(one_off: true, job_fetcher: job_fetcher)
+          end
+
+          let(:test_job) { instance_double('BackgroundJob') }
+
+          before do
+            allow(test_job).to receive(:perform)
+            allow(job_fetcher).to receive(:fetch).and_return(test_job)
+          end
+
+          it 'processes just one job' do
+            subject.work
+            expect(test_job).to have_received(:perform)
+          end
+        end
+
+        describe 'when a job raises' do
+          subject do
+            WorkerAsync.new(one_off: true, job_fetcher: job_fetcher)
+          end
+
+          let(:test_job) { instance_double('BackgroundJob') }
+          let(:error) { Exception.new('test error') }
+
+          before do
+            allow(test_job).to receive(:perform).and_raise(error)
+            allow(test_job).to receive(:fail)
+            allow(job_fetcher).to receive(:fetch).and_return(test_job)
+          end
+
+          it 'sends fail() to the job' do
+            subject.work
+            expect(test_job).to have_received(:fail).with(error)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -27,11 +27,6 @@ class WorkerTest < Test::Unit::TestCase
     Metric.save(:service_id => @service_id, :id => @metric_id, :name => 'hits')
   end
 
-  def test_queue_name
-    assert_equal :priority, Worker::QUEUES[0]
-    assert_equal :main, Worker::QUEUES[1]
-  end
-
   def test_format_of_a_job
     encoded_job = Yajl::Encoder.encode(:class => 'TestJob', :args => [{'0'=> {:app_id => "app_id with spaces"}}])
     assert_equal '{"class":"TestJob","args":[{"0":{"app_id":"app_id with spaces"}}]}', encoded_job
@@ -39,7 +34,7 @@ class WorkerTest < Test::Unit::TestCase
 
   def test_no_jobs_in_the_queue
     redis = Redis.any_instance
-    redis.expects(:blpop).with(*Worker::QUEUES.map{|q| "resque:queue:#{q}"}, {:timeout => 60}).returns(nil)
+    redis.expects(:blpop).returns(nil)
 
     Worker.work(:one_off => true)
   end


### PR DESCRIPTION
This PR continues the work started in #77 

It adds a `Worker` class that processes jobs using the async storage introduced in #77

Notice that the base branch of this PR is the integration branch `async`, not `master`.

Note: CircleCI fails because the CI image contains a ruby version that is not compatible with this feature (async lib requires ruby >= 2.2.7).
