### PR TITLE
Introduce new limit header with the new quota after the limit period ends

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -55,6 +55,8 @@ non-existing metrics occur):
 * `3scale-limit-reset`: An integer stating the amount of seconds left for the
   current limiting period to elapse. A negative integer value means there is no
   limit in time.
+* `3scale-limit-max-value`: An integer stating the maximum total number of hits
+  allowed in the current limiting period.
 
 When a `usage` is specified, only the metrics specified in that usage and their
 parent metrics are taken into account when calculating the limit headers.

--- a/lib/3scale/backend/transactor/limit_headers.rb
+++ b/lib/3scale/backend/transactor/limit_headers.rb
@@ -14,7 +14,8 @@ module ThreeScale
             if report && report.remaining_same_calls != -1
               {
                 remaining: report.remaining_same_calls,
-                reset: report.remaining_time(now)
+                reset: report.remaining_time(now),
+                'max-value': report.max_value
               }
             else
               UNCONSTRAINED

--- a/spec/unit/limit_headers_spec.rb
+++ b/spec/unit/limit_headers_spec.rb
@@ -16,14 +16,16 @@ module ThreeScale
               object_double(Status::UsageReport.allocate,
                             period: Period::Month.new(Time.now.utc),
                             remaining_same_calls: 10,
-                            remaining_time: 100)
+                            remaining_time: 100,
+                            max_value: 200)
             end
 
-            it 'returns the remaining and the reset time for that report' do
+            it 'returns the remaining, the reset time, and the max value for that report' do
               result = subject.get([report])
 
               expected = { remaining: report.remaining_same_calls,
-                           reset: report.remaining_time }
+                           reset: report.remaining_time,
+                           'max-value': report.max_value }
               expect(result).to eq expected
             end
           end
@@ -36,22 +38,25 @@ module ThreeScale
                 object_double(Status::UsageReport.allocate,
                               period: Period::Month.new(time),
                               remaining_same_calls: 10,
-                              remaining_time: 100)
+                              remaining_time: 100,
+                              max_value: 50)
               end
 
               let(:report_year) do
                 object_double(Status::UsageReport.allocate,
                               period: Period::Year.new(time),
                               remaining_same_calls: 10,
-                              remaining_time: 200)
+                              remaining_time: 200,
+                              max_value: 100)
               end
 
-              it 'returns the remaining and reset time of the report with the '\
-                 'longest period' do
+              it 'returns the remaining, the reset time, and the max value '\
+                 'of the report with the longest period' do
                 result = subject.get([report_month, report_year])
 
                 expected = { remaining: report_year.remaining_same_calls,
-                             reset: report_year.remaining_time }
+                             reset: report_year.remaining_time,
+                             'max-value': report_year.max_value }
                 expect(result).to eq expected
               end
             end
@@ -63,23 +68,26 @@ module ThreeScale
                 object_double(Status::UsageReport.allocate,
                               period: Period::Month.new(time),
                               remaining_same_calls: 10,
-                              remaining_time: 100)
+                              remaining_time: 100,
+                              max_value: 200)
               end
 
               let(:report_less_remaining) do
                 object_double(Status::UsageReport.allocate,
                               period: Period::Month.new(time),
                               remaining_same_calls: report_more_remaining.remaining_same_calls - 1,
-                              remaining_time: 200)
+                              remaining_time: 200,
+                              max_value: 300)
               end
 
-              it 'returns the remaining and reset time of the report with the '\
-                 'smallest remaining' do
+              it 'returns the remaining, the reset time, and the max value '\
+                 'of the report with the smallest remaining' do
                 result = subject.get([report_more_remaining,
                                       report_less_remaining])
 
                 expected = { remaining: report_less_remaining.remaining_same_calls,
-                             reset: report_less_remaining.remaining_time }
+                             reset: report_less_remaining.remaining_time,
+                             'max-value': report_less_remaining.max_value }
                 expect(result).to eq expected
               end
             end
@@ -91,23 +99,27 @@ module ThreeScale
                 object_double(Status::UsageReport.allocate,
                               period: Period::Day.new(time),
                               remaining_same_calls: 100,
-                              remaining_time: 65)
+                              remaining_time: 65,
+                              max_value: 100)
               end
 
               let(:report_with_0_remaining) do
                 object_double(Status::UsageReport.allocate,
                               period: Period::Hour.new(time),
                               remaining_same_calls: 0,
-                              remaining_time: 5)
+                              remaining_time: 5,
+                              max_value: 200)
               end
 
-              it 'returns a remaining of 0 and the reset time of the report with 0 remaining' do
+              it 'returns a remaining of 0, the reset time, and the max '\
+                 'value of the report with 0 remaining' do
                 result = subject.get([report_with_some_remaining,
                                       report_with_0_remaining])
 
                 expect(result).to eq(
                   { remaining: 0,
-                    reset: report_with_0_remaining.remaining_time })
+                    reset: report_with_0_remaining.remaining_time,
+                    'max-value': report_with_0_remaining.max_value })
               end
             end
           end

--- a/test/integration/authorize/limit_headers_test.rb
+++ b/test/integration/authorize/limit_headers_test.rb
@@ -69,6 +69,8 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
     remaining_secs_in_day = (Period::Day.new(current_time).finish - current_time).ceil
     assert_equal remaining_secs_in_day,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit_metric1, last_response.header['3scale-limit-max-value']
   end
 
   test 'response headers include correct information when rate-limited' do
@@ -98,6 +100,7 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
     # Check that the remaining and reset refer to the hour limit
     assert_equal 0, last_response.header['3scale-limit-remaining']
     assert_equal 1, last_response.header['3scale-limit-reset']
+    assert_equal hour_limit[:hour], last_response.header['3scale-limit-max-value']
   end
 
   test 'remaining in limit headers is 0 when over limits' do
@@ -126,6 +129,8 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
     remaining_secs_in_day = (Period::Day.new(current_time).finish - current_time).ceil
     assert_equal remaining_secs_in_day,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test 'when a usage is passed, only take into account the metrics in the usage' do
@@ -167,6 +172,8 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
 
     assert_equal (Period::Day.new(current_time).finish - current_time).ceil,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test 'when a usage is passed, remaining/reset can refer to a parent metric' do
@@ -206,6 +213,8 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
 
     assert_equal (Period::Day.new(current_time).finish - current_time).ceil,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal parent_limit, last_response.header['3scale-limit-max-value']
   end
 
   test 'remaining and reset in headers are negative when there are no limits' do
@@ -216,6 +225,7 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
 
     assert last_response.header['3scale-limit-remaining'].to_i < 0
     assert last_response.header['3scale-limit-reset'].to_i < 0
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 
   test 'reset in limit headers is negative when the period is eternity' do
@@ -238,6 +248,8 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
                  last_response.header['3scale-limit-remaining']
 
     assert last_response.header['3scale-limit-reset'].to_i < 0
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test 'limit headers are not returned when there is an error != limits exceeded' do
@@ -266,6 +278,7 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
 
     assert_nil last_response.header['3scale-limit-reset']
     assert_nil last_response.header['3scale-limit-remaining']
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 
   test 'response headers do not include limit headers whe not asked via extensions' do
@@ -280,5 +293,6 @@ class AuthorizeLimitHeadersTest < Test::Unit::TestCase
 
     assert_nil last_response.header['3scale-limit-remaining']
     assert_nil last_response.header['3scale-limit-reset']
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 end

--- a/test/integration/authrep/limit_headers_test.rb
+++ b/test/integration/authrep/limit_headers_test.rb
@@ -70,6 +70,8 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
     remaining_secs_in_day = (Period::Day.new(current_time).finish - current_time).ceil
     assert_equal remaining_secs_in_day,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit_metric1, last_response.header['3scale-limit-max-value']
   end
 
   test_authrep 'response headers include correct information when rate-limited' do |e|
@@ -99,6 +101,7 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
     # Check that the remaining and reset refer to the hour limit
     assert_equal 0, last_response.header['3scale-limit-remaining']
     assert_equal 1, last_response.header['3scale-limit-reset']
+    assert_equal hour_limit[:hour], last_response.header['3scale-limit-max-value']
   end
 
   test_authrep 'remaining in limit headers is 0 when over limits' do |e|
@@ -127,6 +130,8 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
     remaining_secs_in_day = (Period::Day.new(current_time).finish - current_time).ceil
     assert_equal remaining_secs_in_day,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test_authrep 'when a usage is passed, only take into account the metrics in the usage' do |e|
@@ -168,6 +173,8 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
 
     assert_equal (Period::Day.new(current_time).finish - current_time).ceil,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test_authrep 'when a usage is passed, remaining/reset can refer to a parent metric' do |e|
@@ -207,6 +214,8 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
 
     assert_equal (Period::Day.new(current_time).finish - current_time).ceil,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal parent_limit, last_response.header['3scale-limit-max-value']
   end
 
   test_authrep 'remaining and reset in headers are negative when there are no limits' do |e|
@@ -217,6 +226,7 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
 
     assert last_response.header['3scale-limit-remaining'].to_i < 0
     assert last_response.header['3scale-limit-reset'].to_i < 0
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 
   test_authrep 'reset in limit headers is negative when the period is eternity' do |e|
@@ -239,6 +249,8 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
                  last_response.header['3scale-limit-remaining']
 
     assert last_response.header['3scale-limit-reset'].to_i < 0
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test_authrep 'limit headers are not returned when there is an error != limits exceeded' do |e|
@@ -256,6 +268,7 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
 
     assert_nil last_response.header['3scale-limit-reset']
     assert_nil last_response.header['3scale-limit-remaining']
+    assert_nil last_response.header['3scale-limit-max-value']
 
     # application_key_invalid as an example of check performed in a validator.
     @application.create_key('foo')
@@ -267,6 +280,7 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
 
     assert_nil last_response.header['3scale-limit-reset']
     assert_nil last_response.header['3scale-limit-remaining']
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 
   test_authrep 'response headers do not include limit headers whe not asked via extensions' do |e|
@@ -280,5 +294,6 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
 
     assert_nil last_response.header['3scale-limit-remaining']
     assert_nil last_response.header['3scale-limit-reset']
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 end

--- a/test/integration/oauth/limit_headers_test.rb
+++ b/test/integration/oauth/limit_headers_test.rb
@@ -80,6 +80,8 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
     remaining_secs_in_day = (Period::Day.new(current_time).finish - current_time).ceil
     assert_equal remaining_secs_in_day,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit_metric1, last_response.header['3scale-limit-max-value']
   end
 
   test 'response headers include correct information when rate-limited' do
@@ -111,6 +113,7 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
     # Check that the remaining and reset refer to the hour limit
     assert_equal 0, last_response.header['3scale-limit-remaining']
     assert_equal 1, last_response.header['3scale-limit-reset']
+    assert_equal hour_limit[:hour], last_response.header['3scale-limit-max-value']
   end
 
   test 'remaining in limit headers is 0 when over limits' do
@@ -142,6 +145,8 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
     remaining_secs_in_day = (Period::Day.new(current_time).finish - current_time).ceil
     assert_equal remaining_secs_in_day,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test 'when a usage is passed, only take into account the metrics in the usage' do
@@ -184,6 +189,8 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
 
     assert_equal (Period::Day.new(current_time).finish - current_time).ceil,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test 'when a usage is passed, remaining/reset can refer to a parent metric' do
@@ -224,6 +231,8 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
 
     assert_equal (Period::Day.new(current_time).finish - current_time).ceil,
                  last_response.header['3scale-limit-reset']
+
+    assert_equal parent_limit, last_response.header['3scale-limit-max-value']
   end
 
   test 'remaining and reset in headers are negative when there are no limits' do
@@ -236,6 +245,7 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
 
     assert last_response.header['3scale-limit-remaining'].to_i < 0
     assert last_response.header['3scale-limit-reset'].to_i < 0
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 
   test 'reset in limit headers is negative when the period is eternity' do
@@ -260,6 +270,8 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
                  last_response.header['3scale-limit-remaining']
 
     assert last_response.header['3scale-limit-reset'].to_i < 0
+
+    assert_equal limit, last_response.header['3scale-limit-max-value']
   end
 
   test 'limit headers are not returned when there is an error != limits exceeded' do
@@ -292,6 +304,7 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
 
     assert_nil last_response.header['3scale-limit-reset']
     assert_nil last_response.header['3scale-limit-remaining']
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 
   test 'response headers do not include limit headers whe not asked via extensions' do
@@ -307,5 +320,6 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
 
     assert_nil last_response.header['3scale-limit-remaining']
     assert_nil last_response.header['3scale-limit-reset']
+    assert_nil last_response.header['3scale-limit-max-value']
   end
 end


### PR DESCRIPTION
This PR introduces a new limit header, "3scale-limit-value-after-reset" that returns the new quota after the current limiting period ends.

This is needed by APIcast. When the request is limited, APIcast needs to know whether it was because the limit was 0 (which means that the metric is disabled). APIcast needs to do so without parsing the body, so it relies on the limit headers. However, using the current ones there's no way to know if the limit is 0.

Returning a boolean instead of the new quota is another option, but I thought that returning the new quota gives more information without adding any complexity to the code.

Refs:
[THREESCALE-2756](https://issues.jboss.org/browse/THREESCALE-2756)
[THREESCALE-2755](https://issues.jboss.org/browse/THREESCALE-2755)
