### PR TITLE
openshift images: update Pisoni and fix example

### DIFF
--- a/openshift/Dockerfile.core
+++ b/openshift/Dockerfile.core
@@ -1,8 +1,0 @@
-FROM quay.io/3scale/ruby-base:xenial-2.2.4
-
-ARG BUNDLE_GEMINABOX="geminabox_user:geminabox_password"
-ARG CORE_VERSION
-
-RUN gem install 3scale_core --version ${CORE_VERSION} --no-document --source "https://${BUNDLE_GEMINABOX}@host"
-
-USER 1001

--- a/openshift/Dockerfile.pisoni
+++ b/openshift/Dockerfile.pisoni
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ruby-25
+
+ARG PISONI_VERSION
+
+RUN gem install pisoni --version ${PISONI_VERSION} --no-document
+
+USER 1001

--- a/openshift/docker-compose.yml
+++ b/openshift/docker-compose.yml
@@ -23,10 +23,10 @@ services:
       RACK_ENV: production
   test:
     build:
-      dockerfile: Dockerfile.core
+      dockerfile: Dockerfile.pisoni
       context: .
       args:
-        - CORE_VERSION=1.20.0
+        - PISONI_VERSION=1.27.0
     command: ruby test.rb
     depends_on:
       - listener

--- a/openshift/docker-compose.yml
+++ b/openshift/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       CONFIG_REDIS_PROXY: redis:6379
       CONFIG_QUEUES_MASTER_NAME: redis:6379
       RACK_ENV: production
+      CONFIG_INTERNAL_API_USER: user
+      CONFIG_INTERNAL_API_PASSWORD: password
   worker:
     image: ${LOCAL_IMAGE}
     command: 3scale_backend_worker start --ontop
@@ -26,8 +28,8 @@ services:
       dockerfile: Dockerfile.pisoni
       context: .
       args:
-        - PISONI_VERSION=1.27.0
-    command: ruby test.rb
+        PISONI_VERSION: 1.27.0
+    command: ruby /opt/app/test.rb
     depends_on:
       - listener
       - worker
@@ -35,5 +37,7 @@ services:
       - ./test.rb:/opt/app/test.rb:ro
     environment:
       BACKEND_ENDPOINT: http://listener:3000
+      CONFIG_INTERNAL_API_USER: user
+      CONFIG_INTERNAL_API_PASSWORD: password
   redis:
     image: redis:alpine

--- a/openshift/test.rb
+++ b/openshift/test.rb
@@ -16,7 +16,9 @@ uri.path = '/internal/'
 puts "Backend endpoint: #{uri}"
 puts
 
-ThreeScale::Core.donbot_url = uri
+ThreeScale::Core.url = uri
+ThreeScale::Core.username = ENV['CONFIG_INTERNAL_API_USER']
+ThreeScale::Core.password = ENV['CONFIG_INTERNAL_API_PASSWORD']
 
 service_id = ENV.fetch('SERVICE_ID', SecureRandom.hex(4))
 provider_key = ENV.fetch('PROVIDER_KEY', SecureRandom.uuid)


### PR DESCRIPTION
The docker-compose example under the `openshift` directory was not working properly. This PR fixes the example and upgrades Pisoni to the latest version available in Rubygems. The example was still referencing a version from a private repo.