### PR TITLE
Prometheus metrics for workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,10 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - rbenv-dependencies-{{ checksum ".ruby-version" }}
+          - v1-rbenv-dependencies-{{ checksum ".ruby-version" }}
           - v1-dependencies-{{ checksum "Gemfile.lock" }}
           # fallback to using the latest cache if no exact match is found
-          - rbenv-dependencies-
+          - v1-rbenv-dependencies-
           - v1-dependencies-
 
       - run:
@@ -50,7 +50,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.rbenv
-          key: rbenv-dependencies-{{ checksum ".ruby-version" }}
+          key: v1-rbenv-dependencies-{{ checksum ".ruby-version" }}
 
       - run:
           name: bundle install

--- a/Gemfile.base
+++ b/Gemfile.base
@@ -60,3 +60,5 @@ gem 'sinatra', '~> 2.0.3'
 gem 'sinatra-contrib', '~> 2.0.3'
 # Optional external error logging services
 gem 'bugsnag', '~> 6', require: nil
+gem 'prometheus-client'
+gem 'yabeda-prometheus', '= 0.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     daemons (1.2.4)
     diff-lcs (1.3)
     docile (1.1.5)
+    dry-initializer (3.0.1)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     geminabox (0.13.11)
@@ -115,6 +116,8 @@ GEM
     pg (0.20.0)
     pkg-config (1.1.9)
     power_assert (1.1.1)
+    prometheus-client (0.9.0)
+      quantile (~> 0.2.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -124,6 +127,7 @@ GEM
     pry-doc (0.11.1)
       pry (~> 0.9)
       yard (~> 0.9)
+    quantile (0.2.1)
     rack (2.0.6)
     rack-protection (2.0.3)
       rack
@@ -196,6 +200,11 @@ GEM
       chronic (>= 0.6.3)
     with_env (1.1.0)
     xml-simple (1.1.5)
+    yabeda (0.1.3)
+      concurrent-ruby
+      dry-initializer
+    yabeda-prometheus (0.1.4)
+      yabeda
     yajl-ruby (1.3.1)
     yard (0.9.20)
 
@@ -220,6 +229,7 @@ DEPENDENCIES
   nokogiri (~> 1.9.1)
   pg (= 0.20.0)
   pkg-config (~> 1.1.7)
+  prometheus-client
   pry (~> 0.11.3)
   pry-byebug (~> 3.5.1)
   pry-doc (~> 0.11.1)
@@ -242,6 +252,7 @@ DEPENDENCIES
   test-unit (~> 3.2.6)
   timecop (~> 0.9.1)
   whenever (= 0.9.7)
+  yabeda-prometheus (= 0.1.4)
   yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -59,6 +59,7 @@ GEM
     daemons (1.2.4)
     diff-lcs (1.3)
     docile (1.1.5)
+    dry-initializer (3.0.1)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     geminabox (0.13.11)
@@ -103,6 +104,8 @@ GEM
       mini_portile2 (~> 2.4.0)
     pkg-config (1.1.9)
     power_assert (1.1.1)
+    prometheus-client (0.9.0)
+      quantile (~> 0.2.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -112,6 +115,7 @@ GEM
     pry-doc (0.11.1)
       pry (~> 0.9)
       yard (~> 0.9)
+    quantile (0.2.1)
     rack (2.0.6)
     rack-protection (2.0.3)
       rack
@@ -180,6 +184,11 @@ GEM
       rack (>= 1.0.0)
     with_env (1.1.0)
     xml-simple (1.1.5)
+    yabeda (0.1.3)
+      concurrent-ruby
+      dry-initializer
+    yabeda-prometheus (0.1.4)
+      yabeda
     yajl-ruby (1.3.1)
     yard (0.9.20)
 
@@ -201,6 +210,7 @@ DEPENDENCIES
   mocha (~> 1.3)
   nokogiri (~> 1.9.1)
   pkg-config (~> 1.1.7)
+  prometheus-client
   pry (~> 0.11.3)
   pry-byebug (~> 3.5.1)
   pry-doc (~> 0.11.1)
@@ -220,6 +230,7 @@ DEPENDENCIES
   sshkit
   test-unit (~> 3.2.6)
   timecop (~> 0.9.1)
+  yabeda-prometheus (= 0.1.4)
   yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH

--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -1,0 +1,6 @@
+# Prometheus metrics
+
+| Metric                                | Description                        | Type      | Labels                           |
+|---------------------------------------|------------------------------------|-----------|----------------------------------|
+| apisonator_worker_job_count           | Number of jobs processed           | counter   | type(ReportJob, NotifyJob, etc.) |
+| apisonator_worker_job_runtime_seconds | How long the jobs take to complete | histogram | type(ReportJob, NotifyJob, etc.) |

--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -58,6 +58,7 @@ module ThreeScale
       config.add_section(:internal_api, :user, :password)
       config.add_section(:oauth, :max_token_size)
       config.add_section(:master, :metrics)
+      config.add_section(:worker_prometheus_metrics, :enabled, :port)
 
       # Configure nested fields
       master_metrics = [:transactions, :transactions_authorize]

--- a/lib/3scale/backend/worker.rb
+++ b/lib/3scale/backend/worker.rb
@@ -27,6 +27,12 @@ module ThreeScale
       def self.new(options = {})
         Logging::Worker.configure_logging(self, options[:log_file])
         Logging::External.setup_worker
+
+        if configuration.worker_prometheus_metrics.enabled
+          require '3scale/backend/worker_metrics'
+          WorkerMetrics.start_metrics_server
+        end
+
         super
       end
 

--- a/lib/3scale/backend/worker_metrics.rb
+++ b/lib/3scale/backend/worker_metrics.rb
@@ -1,0 +1,39 @@
+require 'yabeda/prometheus'
+
+Yabeda.configure do
+  group :apisonator_worker do
+    counter :job_count, comment: "Total number of jobs processed"
+
+    histogram :job_runtime do
+      comment "How long jobs take to run"
+      unit :seconds
+      buckets [0.005, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+    end
+  end
+end
+
+module ThreeScale
+  module Backend
+    class WorkerMetrics
+      include Configurable
+
+      def self.start_metrics_server
+        # Yabeda does not accept the port as a param
+        port = configuration.worker_prometheus_metrics.port
+        ENV['PROMETHEUS_EXPORTER_PORT'] = port.to_s if port
+
+        Yabeda::Prometheus::Exporter.start_metrics_server!
+      end
+
+      def self.increase_job_count(job_class_name)
+        Yabeda.apisonator_worker.job_count.increment(
+            { type: job_class_name }, by: 1
+        )
+      end
+
+      def self.report_runtime(job_class_name, runtime)
+        Yabeda.apisonator_worker.job_runtime.measure({ type: job_class_name }, runtime)
+      end
+    end
+  end
+end

--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -55,4 +55,6 @@ ThreeScale::Backend.configure do |config|
   config.oauth.max_token_size = parse_int_env('CONFIG_OAUTH_MAX_TOKEN_SIZE')
   config.request_loggers = parse_request_loggers
   config.workers_logger_formatter = "#{ENV['CONFIG_WORKERS_LOGGER_FORMATTER']}".to_sym
+  config.worker_prometheus_metrics.enabled = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true' ? true : false
+  config.worker_prometheus_metrics.port = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_PORT']
 end

--- a/spec/integration/worker_metrics_spec.rb
+++ b/spec/integration/worker_metrics_spec.rb
@@ -1,0 +1,129 @@
+require_relative '../spec_helper'
+require '3scale/backend/worker_metrics'
+
+require 'net/http'
+
+module ThreeScale
+  module Backend
+    describe WorkerMetrics do
+      include SpecHelpers::ConfigHelper
+
+      let(:provider_key) { 'a_provider_key' }
+      let(:service_id) { 'a_service_id' }
+      let(:app_id) { 'an_app_id' }
+      let(:metric_id) { 'a_metric_id' }
+      let(:metric_name) { 'hits' }
+
+      let(:config) { Backend.configuration }
+
+      let(:n_jobs) { 5 }
+
+      let(:metrics_endpoint) { '/metrics' }
+      let(:metrics_port) { 9394 }
+
+      default_metrics_enabled = Backend.configuration.worker_prometheus_metrics
+
+      before do
+        Service.save!(provider_key: provider_key, id: service_id)
+        Application.save(service_id: service_id, id: app_id, state: :active)
+        Metric.save(service_id: service_id, id: metric_id, name: metric_name)
+      end
+
+      after do
+        config.worker_prometheus_metrics.enabled = default_metrics_enabled
+      end
+
+      context 'when prometheus metrics are enabled' do
+        before do
+          enable_worker_prometheus_metrics
+          report_jobs(n_jobs)
+          process_jobs(n_jobs)
+        end
+
+        after do
+          shutdown_metrics_server
+        end
+
+        it 'exposes them' do
+          sleep(1) # The web server takes a bit to start
+
+          resp = Net::HTTP.get('localhost', metrics_endpoint, metrics_port)
+
+          expect(resp).to match(
+/TYPE apisonator_worker_job_count counter
+# HELP apisonator_worker_job_count Total number of jobs processed
+apisonator_worker_job_count{type="ReportJob"} #{n_jobs}
+# TYPE apisonator_worker_job_runtime_seconds histogram
+# HELP apisonator_worker_job_runtime_seconds How long jobs take to run
+.*
+apisonator_worker_job_runtime_seconds_sum{type="ReportJob"} \d+\.\d+
+apisonator_worker_job_runtime_seconds_count{type="ReportJob"} \d+\.\d+
+/m)
+        end
+      end
+
+      context 'when prometheus metrics are enabled on a given port' do
+        let(:port) { 7777 }
+
+        before do
+          enable_worker_prometheus_metrics
+          set_worker_prometheus_metrics_port(port)
+          WorkerMetrics.start_metrics_server
+        end
+
+        after do
+          reset_worker_prometheus_metrics_port
+          shutdown_metrics_server
+        end
+
+        it 'exposes the metrics' do
+          sleep(1) # The web server takes a bit to start
+
+          resp = Net::HTTP.get('localhost', metrics_endpoint, port)
+
+          expect(resp).not_to be_nil
+        end
+      end
+
+      context 'when prometheus metrics are not enabled' do
+        before do
+          disable_worker_prometheus_metrics
+          report_jobs(n_jobs)
+          process_jobs(n_jobs)
+        end
+
+        it 'does not expose them' do
+          sleep(1) # The web server takes a bit to start
+
+          expect { Net::HTTP.get('localhost', metrics_endpoint, metrics_port) }
+                 .to raise_error(Errno::EADDRNOTAVAIL)
+        end
+      end
+
+      private
+
+      def report_jobs(num)
+        without_resque_spec do
+          num.times do
+            Transactor.report(
+                provider_key,
+                service_id,
+                0 => { app_id: app_id, usage: { metric_name => 1 } }
+            )
+          end
+        end
+      end
+
+      def process_jobs(num)
+        without_resque_spec do
+          num.times { Worker.work(one_off: true) }
+        end
+      end
+
+      def shutdown_metrics_server
+        # Yabeda does not expose this
+        ::Rack::Handler::WEBrick.shutdown
+      end
+    end
+  end
+end

--- a/spec/spec_helpers/config_helper.rb
+++ b/spec/spec_helpers/config_helper.rb
@@ -1,0 +1,31 @@
+module SpecHelpers
+  module ConfigHelper
+    include ThreeScale::Backend::Configurable
+
+    def enable_worker_prometheus_metrics
+      prometheus_worker_metrics_opts.enabled = true
+    end
+
+    def disable_worker_prometheus_metrics
+      prometheus_worker_metrics_opts.enabled = false
+    end
+
+    def reset_worker_prometheus_metrics_state
+      disable_worker_prometheus_metrics
+    end
+
+    def set_worker_prometheus_metrics_port(port)
+      prometheus_worker_metrics_opts.port = port
+    end
+
+    def reset_worker_prometheus_metrics_port
+      prometheus_worker_metrics_opts.port = 9394
+    end
+
+    private
+
+    def prometheus_worker_metrics_opts
+      configuration.worker_prometheus_metrics
+    end
+  end
+end

--- a/spec/unit/jobs/background_job_spec.rb
+++ b/spec/unit/jobs/background_job_spec.rb
@@ -1,8 +1,11 @@
 require_relative '../../spec_helper'
+require '3scale/backend/worker_metrics'
 
 module ThreeScale
   module Backend
     describe BackgroundJob do
+      include SpecHelpers::ConfigHelper
+
       class FooJob < BackgroundJob
 
         def self.perform_logged(*args)
@@ -42,6 +45,34 @@ module ThreeScale
         it 'complains when you don\'t set a log message' do
           expect { BarJob.perform() }.to raise_error(
             BackgroundJob::Error, 'No job message given')
+        end
+      end
+
+      describe '.perform' do
+        after(:all) { reset_worker_prometheus_metrics_state }
+
+        context 'when Prometheus metrics are enabled' do
+          before { enable_worker_prometheus_metrics }
+
+          it 'reports type of job performed and runtime' do
+            expect(WorkerMetrics).to receive(:increase_job_count).with('FooJob')
+
+            expect(WorkerMetrics).to receive(:report_runtime)
+                                 .with('FooJob', satisfy { |v| v > 0 })
+
+            FooJob.perform(Time.now.getutc.to_f)
+          end
+        end
+
+        context 'when Prometheus metrics are disabled' do
+          before { disable_worker_prometheus_metrics }
+
+          it 'does not update any Prometheus metric' do
+            expect(WorkerMetrics).not_to receive(:increase_job_count)
+            expect(WorkerMetrics).not_to receive(:report_runtime)
+
+            FooJob.perform(Time.now.getutc.to_f)
+          end
         end
       end
     end


### PR DESCRIPTION
This PR adds Prometheus metrics for workers.

It uses the [yabeda-prometheus gem](https://github.com/yabeda-rb/yabeda-prometheus). It basically creates a web service on a separate thread that exposes `/metrics`.

This feature is opt-in. There are a couple of new config params. One for enabling the feature (`ENV['CONFIG_WORKER_PROMETHEUS_METRICS_ENABLED']`) and another one for selecting the port for the metrics web service (`ENV['CONFIG_WORKER_PROMETHEUS_METRICS_PORT']`).

For now, I added a couple of metrics (see `docs/prometheus_metrics.md`):

```
| Metric                                | Description                        | Type      | Labels                           |
|---------------------------------------|------------------------------------|-----------|----------------------------------|
| apisonator_worker_job_count           | Number of jobs processed           | counter   | type(ReportJob, NotifyJob, etc.) |
| apisonator_worker_job_runtime_seconds | How long the jobs take to complete | histogram | type(ReportJob, NotifyJob, etc.) |
```

/cc @slopezz