### PR TITLE
clean-up: delete unnecessary 'before' in Utilization specs

### DIFF
--- a/spec/acceptance/api/internal/utilization_api_spec.rb
+++ b/spec/acceptance/api/internal/utilization_api_spec.rb
@@ -4,11 +4,6 @@ resource 'Utilization (prefix: /services/:service_id/applications/:app_id/utiliz
   header 'Accept', 'application/json'
   header 'Content-Type', 'application/json'
 
-  before(:all) do
-    ThreeScale::Backend::Storage.instance(true).flushdb
-    ThreeScale::Backend::Memoizer.reset!
-  end
-
   # Service IDs
   let(:service_id) { '1111' }
   let(:non_existing_service_id) { service_id.to_i.succ.to_s }


### PR DESCRIPTION
Minor clean-up extracted from #96.

The other before blocks already set up everything needed without regards of previous contents.