### PR TITLE
Update Nokogiri to 1.10.4

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -17,7 +17,7 @@ end
 group :test do
   gem 'benchmark-ips', '~> 2.7.2'
   gem 'mocha',         '~> 1.3'
-  gem 'nokogiri',      '~> 1.9.1'
+  gem 'nokogiri',      '~> 1.10.4'
   gem 'pkg-config',    '~> 1.1.7'
   gem 'rack-test',     '~> 0.8.2'
   gem 'resque_unit',   '~> 0.4.4', source: 'https://rubygems.org'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nokogiri (1.9.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parslet (1.8.2)
     pg (0.20.0)
@@ -217,7 +217,7 @@ DEPENDENCIES
   hiredis (= 0.6.1)
   license_finder (~> 5)
   mocha (~> 1.3)
-  nokogiri (~> 1.9.1)
+  nokogiri (~> 1.10.4)
   pg (= 0.20.0)
   pkg-config (~> 1.1.7)
   prometheus-client

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -89,7 +89,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nokogiri (1.9.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parslet (1.8.2)
     pkg-config (1.1.9)
@@ -199,7 +199,7 @@ DEPENDENCIES
   hiredis (= 0.6.1)
   license_finder (~> 5)
   mocha (~> 1.3)
-  nokogiri (~> 1.9.1)
+  nokogiri (~> 1.10.4)
   pkg-config (~> 1.1.7)
   prometheus-client
   pry (~> 0.11.3)


### PR DESCRIPTION
The new version fixes this CVE: https://nvd.nist.gov/vuln/detail/CVE-2019-5477

The project is not vulnerable. The method mentioned there is not called.