### PR TITLE
Add support for metric hierarchies with more than 2 levels

### DIFF
--- a/lib/3scale/backend/metric.rb
+++ b/lib/3scale/backend/metric.rb
@@ -149,6 +149,19 @@ module ThreeScale
           hierarchy(service_id, false)[id.to_s]
         end
 
+        # Returns the "descendants" of a metric, that is, its children,
+        # grandchildren, etc. in the metric hierarchy of the given service.
+        # In other words, the "descendants" of a metric are its children plus
+        # the descendants of each of them.
+        def descendants(service_id, metric_name)
+          metrics_hierarchy = hierarchy(service_id)
+          children = metrics_hierarchy[metric_name] || []
+
+          children.reduce(children) do |acc, child|
+            acc + descendants(service_id, child)
+          end
+        end
+
         # Given an array of metrics, returns an array without duplicates that
         # includes the names of the metrics that are parent of at least one of
         # the given metrics.

--- a/lib/3scale/backend/metric/collection.rb
+++ b/lib/3scale/backend/metric/collection.rb
@@ -40,19 +40,25 @@ module ThreeScale
           end
         end
 
+        # Propagates the usage to all the levels of the hierarchy.
+        # For example, in this scenario:
+        # m1 --child_of--> m2 --child_of--> m3
+        # If there's a +1 in m1, this method will set the +1 in the other 2 as
+        # well.
         def process_parents(usage)
-          usage.keys.inject(usage.dup) do |memo, id|
-            p_id = parent_id(id)
-            if p_id
-              if Usage.is_set? memo[id]
-                memo[p_id] = memo[id]
+          usage.inject(usage.dup) do |memo, (id, val)|
+            is_set_op = Usage.is_set?(val)
+
+            while (id = parent_id(id))
+              if is_set_op
+                memo[id] = val
               else
                 # need the to_i here instead of in parse_usage because the value
-                # can be a string if the parent is passed explictly on the usage
+                # can be a string if the parent is passed explicitly on the usage
                 # since the value might not be a Fixnum but a '#'Fixnum
                 # (also because memo[p_id] might be nil)
-                memo[p_id] = memo[p_id].to_i
-                memo[p_id] += memo[id].to_i
+                memo[id] = memo[id].to_i
+                memo[id] += val.to_i
               end
             end
 

--- a/lib/3scale/backend/transactor/usage_report.rb
+++ b/lib/3scale/backend/transactor/usage_report.rb
@@ -167,7 +167,7 @@ module ThreeScale
               # this is an auth/authrep request and therefore we should sum the usage
               computed_usage = Usage.get_from this_usage, current_value
               # children can alter the resulting current value
-              add_children_usage(usage, computed_usage)
+              add_descendants_usage(usage, computed_usage)
             else
               current_value
             end
@@ -185,6 +185,15 @@ module ThreeScale
               end
             end
             res
+          end
+
+          def add_descendants_usage(usages, parent_usage)
+            descendants = Metric.descendants(@status.service_id, metric_name)
+
+            descendants.reduce(parent_usage) do |acc, descendant|
+              descendant_usage = usages[descendant]
+              Usage.get_from descendant_usage, acc
+            end
           end
         end
       end

--- a/test/integration/authorize/multi_level_hierarchy_test.rb
+++ b/test/integration/authorize/multi_level_hierarchy_test.rb
@@ -1,0 +1,92 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+
+class AuthorizeMultiLevelHierarchyTest < Test::Unit::TestCase
+  include TestHelpers::Fixtures
+  include TestHelpers::Integration
+  include TestHelpers::AuthorizeAssertions
+
+  def setup
+    @storage = Storage.instance(true)
+    @storage.flushdb
+
+    Resque.reset!
+    Memoizer.reset!
+
+    @test_setup = setup_service_with_metric_hierarchy(3)
+  end
+
+  test 'denies when limits exceeded on an intermediate metric of the hierarchy' do
+    # Intermediate in this case means that it's not at the top or the bottom of
+    # the hierarchy. This test reports a number of hits equivalent to the limit
+    # of that metric and then reports +1 on the metric at the bottom of the
+    # hierarchy. That +1 should propagate up in the hierarchy. Therefore, the
+    # request should be denied because of limits exceeded on the intermediate
+    # metric.
+    intermediate_metric = @test_setup[:metrics][1]
+    bottom_metric = @test_setup[:metrics].last
+
+    Transactor.report(
+        @test_setup[:provider_key],
+        @test_setup[:service_id],
+        0 => { app_id: @test_setup[:app_id],
+               usage: { intermediate_metric[:name] => intermediate_metric[:limit] } }
+    )
+
+    Resque.run!
+
+    get '/transactions/authorize.xml',
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    assert_not_authorized 'usage limits are exceeded'
+  end
+
+  test 'denies when limits exceeded on the metric at the top of the hierarchy' do
+    top_metric = @test_setup[:metrics].first
+    bottom_metric = @test_setup[:metrics].last
+
+    Transactor.report(
+      @test_setup[:provider_key],
+      @test_setup[:service_id],
+      0 => { app_id: @test_setup[:app_id],
+             usage: { top_metric[:name] => top_metric[:limit] } }
+    )
+
+    Resque.run!
+
+    get '/transactions/authorize.xml',
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    assert_not_authorized 'usage limits are exceeded'
+  end
+
+  test 'shows information about all the related metrics in the hierarchy' do
+    bottom_metric = @test_setup[:metrics].last
+
+    get '/transactions/authorize.xml',
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    metric_names = @test_setup[:metrics].map { |metric| metric[:name] }
+    xml_usage_reports = Nokogiri::XML(last_response.body).at('usage_reports')
+
+    all_present = metric_names.all? do |name|
+      xml_usage_reports.at("usage_report[metric = \"#{name}\"]")
+    end
+
+    assert_true all_present
+  end
+end

--- a/test/integration/authrep/multi_level_hierarchy_test.rb
+++ b/test/integration/authrep/multi_level_hierarchy_test.rb
@@ -1,0 +1,109 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+
+class AuthrepMultiLevelHierarchyTest < Test::Unit::TestCase
+  include TestHelpers::Fixtures
+  include TestHelpers::Integration
+  include TestHelpers::AuthorizeAssertions
+  include TestHelpers::AuthRep
+
+  def setup
+    @storage = Storage.instance(true)
+    @storage.flushdb
+
+    Resque.reset!
+    Memoizer.reset!
+
+    @test_setup = setup_service_with_metric_hierarchy(3, oauth: true)
+  end
+
+  test_authrep 'denies when limits exceeded on an intermediate metric of the hierarchy' do |e|
+    intermediate_metric = @test_setup[:metrics][1]
+    bottom_metric = @test_setup[:metrics].last
+
+    Transactor.report(
+        @test_setup[:provider_key],
+        @test_setup[:service_id],
+        0 => { app_id: @test_setup[:app_id],
+               usage: { intermediate_metric[:name] => intermediate_metric[:limit] } }
+    )
+
+    Resque.run!
+
+    get e,
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    assert_not_authorized 'usage limits are exceeded'
+  end
+
+  test_authrep 'denies when limits exceeded on the metric at the top of the hierarchy' do |e|
+    top_metric = @test_setup[:metrics].first
+    bottom_metric = @test_setup[:metrics].last
+
+    Transactor.report(
+      @test_setup[:provider_key],
+      @test_setup[:service_id],
+      0 => { app_id: @test_setup[:app_id],
+             usage: { top_metric[:name] => top_metric[:limit] } }
+    )
+
+    Resque.run!
+
+    get e,
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    assert_not_authorized 'usage limits are exceeded'
+  end
+
+  test_authrep 'shows the correct current value for all the metrics in the hierarchy' do |e|
+    bottom_metric = @test_setup[:metrics].last
+
+    get e,
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    metric_names = @test_setup[:metrics].map { |metric| metric[:name] }
+    xml_usage_reports = Nokogiri::XML(last_response.body).at('usage_reports')
+
+    metric_current_values = metric_names.map do |name|
+      xml_usage_reports.at("usage_report[metric = \"#{name}\"]")
+                       .at("current_value")
+                       .content
+                       .to_i
+    end
+
+    assert_true(metric_current_values.all?{ |val| val == 1 })
+  end
+
+  test_authrep 'when authorized, propagates the reports to all the levels in the hierarchy' do |e|
+    bottom_metric = @test_setup[:metrics].last
+
+    get e,
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    app = Application.load!(@test_setup[:service_id], @test_setup[:app_id])
+    usages = Usage.application_usage(app, Time.now)[Period::Day]
+    metric_ids = @test_setup[:metrics].map { |metric| metric[:id] }
+    all_increased = metric_ids.all? { |metric_id| usages[metric_id] == 1 }
+
+    assert_true all_increased
+  end
+end

--- a/test/integration/oauth/multi_level_hierarchy_test.rb
+++ b/test/integration/oauth/multi_level_hierarchy_test.rb
@@ -1,0 +1,86 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+
+class OauthMultiLevelHierarchyTest < Test::Unit::TestCase
+  include TestHelpers::Fixtures
+  include TestHelpers::Integration
+  include TestHelpers::AuthorizeAssertions
+
+  def setup
+    @storage = Storage.instance(true)
+    @storage.flushdb
+
+    Resque.reset!
+    Memoizer.reset!
+
+    @test_setup = setup_service_with_metric_hierarchy(3, oauth: true)
+  end
+
+  test 'denies when limits exceeded on an intermediate metric of the hierarchy' do
+    intermediate_metric = @test_setup[:metrics][1]
+    bottom_metric = @test_setup[:metrics].last
+
+    Transactor.report(
+        @test_setup[:provider_key],
+        @test_setup[:service_id],
+        0 => { app_id: @test_setup[:app_id],
+               usage: { intermediate_metric[:name] => intermediate_metric[:limit] } }
+    )
+
+    Resque.run!
+
+    get '/transactions/oauth_authorize.xml',
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    assert_not_authorized 'usage limits are exceeded'
+  end
+
+  test 'denies when limits exceeded on the metric at the top of the hierarchy' do
+    top_metric = @test_setup[:metrics].first
+    bottom_metric = @test_setup[:metrics].last
+
+    Transactor.report(
+      @test_setup[:provider_key],
+      @test_setup[:service_id],
+      0 => { app_id: @test_setup[:app_id],
+             usage: { top_metric[:name] => top_metric[:limit] } }
+    )
+
+    Resque.run!
+
+    get '/transactions/oauth_authorize.xml',
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    assert_not_authorized 'usage limits are exceeded'
+  end
+
+  test 'shows information about all the related metrics in the hierarchy' do
+    bottom_metric = @test_setup[:metrics].last
+
+    get '/transactions/oauth_authorize.xml',
+        provider_key: @test_setup[:provider_key],
+        service_id: @test_setup[:service_id],
+        app_id: @test_setup[:app_id],
+        usage: { bottom_metric[:name] => 1 }
+
+    Resque.run!
+
+    metric_names = @test_setup[:metrics].map { |metric| metric[:name] }
+    xml_usage_reports = Nokogiri::XML(last_response.body).at('usage_reports')
+
+    all_present = metric_names.all? do |name|
+      xml_usage_reports.at("usage_report[metric = \"#{name}\"]")
+    end
+
+    assert_true all_present
+  end
+end

--- a/test/test_helpers/metrics_hierarchy.rb
+++ b/test/test_helpers/metrics_hierarchy.rb
@@ -1,0 +1,23 @@
+module TestHelpers
+  module MetricsHierarchy
+
+    # Generates a hierarchy of n levels with only one metric per level.
+    # Returns an array with the metrics generated. The metric at pos i is the
+    # parent of the metric at pos i + 1.
+    def gen_hierarchy_one_metric_per_level(service_id, levels)
+      metrics = levels.times.map do |level|
+        ThreeScale::Backend::Metric.new(
+          service_id: service_id, id: next_id, name: "metric_#{level}"
+        )
+      end
+
+      metrics.each_cons(2) do |parent, child|
+        parent.children = [child]
+      end
+
+      metrics.first.save # saves all the descendants too
+
+      metrics
+    end
+  end
+end

--- a/test/unit/metric/collection_test.rb
+++ b/test/unit/metric/collection_test.rb
@@ -2,6 +2,9 @@ require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
 
 module Metric
   class CollectionTest < Test::Unit::TestCase
+    include TestHelpers::Sequences
+    include TestHelpers::MetricsHierarchy
+
     def setup
       Storage.instance(true).flushdb
       Memoizer.reset!
@@ -86,6 +89,29 @@ module Metric
       assert_equal({'2001' => '#6', '2002' => '#6'}, metrics.process_usage('hits_child_1' => '#6'))
       assert_equal({'2001' => '#11', '2002' => '#6', '2003' => '#11'}, metrics.process_usage('hits_child_1' => '#6', 'hits_child_2' => '#11'))
             
+    end
+
+    def test_process_usage_handles_hierarchies_with_more_than_2_levels
+      # This test generates a hierarchy with more than 2 levels and one metric
+      # per level.
+      # Also, it creates a usage where the metrics at the last and last + 1
+      # levels of the hierarchy have 1 hit. Then, it checks that those hits are
+      # correctly propagated, that is, all the metrics in the hierarchy should
+      # have 2 hits, except the one at the bottom which should have only 1.
+
+      service_id = next_id
+      levels = rand(3..10)
+      metrics = gen_hierarchy_one_metric_per_level(service_id, levels)
+
+      metrics_collection = Metric::Collection.new(service_id)
+      processed = metrics_collection.process_usage(
+        metrics.last.name => 1, metrics[-2].name => 1
+      )
+
+      assert_equal(1, processed[metrics.last.id])
+      assert_true metrics[0..-2].all? do |metric|
+        processed[metric.id] == 2
+      end
     end
   end
 end


### PR DESCRIPTION
This PR addresses some of the points in #114 

The PR adds support for metric hierarchies with more than 2 levels. For example:
`m1 --child_of--> m2 --child_of --> m3`

In particular:
- Auth, authrep, and report calls now take into account the whole hierarchy when applying limits.
- The XML returned in authrep calls now shows an updated value for the `current_value` field in all the metrics affected in the hierarchy.

This PR does not adapt the limits and the hierarchy extensions to work with metric hierarchies of more than 2 levels. That will be done in a separate PR.