### PR TITLE
Fix bug that makes worker crash when fetching a job

### DIFF
--- a/lib/3scale/backend/job_fetcher.rb
+++ b/lib/3scale/backend/job_fetcher.rb
@@ -20,7 +20,7 @@ module ThreeScale
       def fetch
         encoded_job = @redis.blpop(*@queues, timeout: @fetch_timeout)
 
-        return nil if encoded_job.blank?
+        return nil if encoded_job.nil? || encoded_job.empty?
 
         begin
           # Resque::Job.new accepts a queue name as a param. It is very


### PR DESCRIPTION
This reverts commit bacb0ba3507ceba75987ca232d2606296b825fb5.

This commit made the worker crash after fetching a job from the queue. The reason is that `Array#blank?` is not defined in our code.

Our tests did not catch this because one of the dependencies that we only use in tests requires `activesupport`, which defines `Array#blank?`