### PR TITLE
Test that the hierarchy extension works well for hierarchies with more than 2 levels

### DIFF
--- a/test/integration/oauth/multi_level_hierarchy_test.rb
+++ b/test/integration/oauth/multi_level_hierarchy_test.rb
@@ -4,6 +4,8 @@ class OauthMultiLevelHierarchyTest < Test::Unit::TestCase
   include TestHelpers::Fixtures
   include TestHelpers::Integration
   include TestHelpers::AuthorizeAssertions
+  include TestHelpers::Extensions
+  include TestHelpers::MetricsHierarchy
 
   def setup
     @storage = Storage.instance(true)
@@ -82,5 +84,25 @@ class OauthMultiLevelHierarchyTest < Test::Unit::TestCase
     end
 
     assert_true all_present
+  end
+
+  test 'response includes correct hierarchy extension info when n_levels > 2' do
+    get '/transactions/oauth_authorize.xml',
+        {
+          provider_key: @test_setup[:provider_key],
+          service_id: @test_setup[:service_id],
+          app_id: @test_setup[:app_id],
+        },
+        'HTTP_3SCALE_OPTIONS' => Extensions::HIERARCHY
+
+    Resque.run!
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    children_xml_correct = @test_setup[:metrics].each_cons(2).all? do |parent, child|
+      children_resp = extract_children_from_resp(xml_resp, parent[:name])
+      children_resp == [child[:name]]
+    end
+
+    assert_true children_xml_correct
   end
 end

--- a/test/test_helpers/metrics_hierarchy.rb
+++ b/test/test_helpers/metrics_hierarchy.rb
@@ -19,5 +19,16 @@ module TestHelpers
 
       metrics
     end
+
+    # Extracts from an XML response, the children of the given metric. Note that
+    # the XML will only contain that info when the hierarchy extension is
+    # enabled.
+    def extract_children_from_resp(xml_response_body, parent_name)
+      xml_response_body.at('hierarchy')
+                       .at("metric[name = '#{parent_name}']")
+                       .attribute('children')
+                       .value
+                       .split # They are separated by spaces
+    end
   end
 end


### PR DESCRIPTION
This PR is part of #114 

The Hierarchy extension was working correctly for hierarchies of more than 2 levels, but there were no tests for that. This PR adds those tests.