### PR TITLE
Limits Header extension: add support for metric hierarchies with more than 2 levels

### DIFF
--- a/lib/3scale/backend/metric.rb
+++ b/lib/3scale/backend/metric.rb
@@ -162,6 +162,17 @@ module ThreeScale
           end
         end
 
+        # Returns the "ascendants" of a metric, that is, its parent,
+        # grandparent, etc. The "ascendants" of a metric are its parent plus
+        # the ascendants of the parent.
+        def ascendants(service_id, metric_name)
+          parents_of_metric = parents(service_id, [metric_name])
+
+          parents_of_metric.reduce(parents_of_metric) do |acc, parent|
+            acc + ascendants(service_id, parent)
+          end
+        end
+
         # Given an array of metrics, returns an array without duplicates that
         # includes the names of the metrics that are parent of at least one of
         # the given metrics.

--- a/lib/3scale/backend/transactor/status.rb
+++ b/lib/3scale/backend/transactor/status.rb
@@ -155,12 +155,14 @@ module ThreeScale
           return all_reports if (@usage.nil? || @usage.empty?)
 
           metric_names_in_usage = @usage.keys
-          metrics = metric_names_in_usage | parents_names(metric_names_in_usage)
+          metrics = metric_names_in_usage | ascendants_names(metric_names_in_usage)
           all_reports.select { |report| metrics.include?(report.metric_name) }
         end
 
-        def parents_names(metric_names)
-          Metric.parents(@service_id, metric_names)
+        def ascendants_names(metric_names)
+          metric_names.flat_map do |metric_name|
+            Metric.ascendants(@service_id, metric_name)
+          end
         end
 
         # make sure the keys are Periods

--- a/lib/3scale/backend/transactor/usage_report.rb
+++ b/lib/3scale/backend/transactor/usage_report.rb
@@ -154,7 +154,7 @@ module ThreeScale
             this_usage = usage[metric_name] || 0
             res = Usage.get_from(this_usage)
 
-            add_children_usage(usage, res)
+            add_descendants_usage(usage, res)
           end
 
           # helper to compute the current usage value after applying a possibly
@@ -171,20 +171,6 @@ module ThreeScale
             else
               current_value
             end
-          end
-
-          def add_children_usage(usages, parent_usage)
-            res = parent_usage
-            children = hierarchy[metric_name]
-            if children
-              # this is a parent metric, so we need to add usage we got
-              # explicited in the usage parameter
-              children.each do |child|
-                child_usage = usages[child]
-                res = Usage.get_from child_usage, res
-              end
-            end
-            res
           end
 
           def add_descendants_usage(usages, parent_usage)

--- a/test/integration/authrep/limit_headers_test.rb
+++ b/test/integration/authrep/limit_headers_test.rb
@@ -296,4 +296,44 @@ class AuthrepLimitHeadersTest < Test::Unit::TestCase
     assert_nil last_response.header['3scale-limit-reset']
     assert_nil last_response.header['3scale-limit-max-value']
   end
+
+  test 'works with metric hierarchies of more than 2 levels' do |e|
+    levels = rand(3..10)
+    test_setup = setup_service_with_metric_hierarchy(levels, set_limits: false)
+    metric_at_top = test_setup[:metrics].first
+    metric_at_bottom = test_setup[:metrics].last
+
+    # Set a limit only for the metric at the top of the hierarchy.
+    # When reporting a hit at the top level we should see the metric at the top
+    # in the resp headers.
+    daily_limit = 100
+    UsageLimit.save(service_id: test_setup[:service_id],
+                    plan_id: test_setup[:plan_id],
+                    metric_id: metric_at_top[:id],
+                    day: daily_limit)
+
+    usage_to_report = 10
+    current_time = Time.now.utc
+    seconds_remaining_day = (Period::Day.new(current_time).finish - current_time).ceil
+
+    Timecop.freeze(Time.now.utc) do
+      get e,
+          { provider_key: test_setup[:provider_key],
+            app_id: test_setup[:app_id],
+            usage: { metric_at_bottom[:name] => usage_to_report }
+          },
+          'HTTP_3SCALE_OPTIONS' => Extensions::LIMIT_HEADERS
+
+      Resque.run!
+    end
+
+    assert_equal daily_limit/usage_to_report - 1,
+                 last_response.header['3scale-limit-remaining']
+
+    assert_equal seconds_remaining_day,
+                 last_response.header['3scale-limit-reset']
+
+    assert_equal daily_limit,
+                 last_response.header['3scale-limit-max-value']
+  end
 end

--- a/test/integration/oauth/limit_headers_test.rb
+++ b/test/integration/oauth/limit_headers_test.rb
@@ -322,4 +322,42 @@ class OauthLimitHeadersTest < Test::Unit::TestCase
     assert_nil last_response.header['3scale-limit-reset']
     assert_nil last_response.header['3scale-limit-max-value']
   end
+
+  test 'works with metric hierarchies of more than 2 levels' do
+    levels = rand(3..10)
+    test_setup = setup_service_with_metric_hierarchy(levels, set_limits: false, oauth: true)
+    metric_at_top = test_setup[:metrics].first
+    metric_at_bottom = test_setup[:metrics].last
+
+    # Set a limit only for the metric at the top of the hierarchy.
+    # When reporting a hit at the top level we should see the metric at the top
+    # in the resp headers.
+    daily_limit = 100
+    UsageLimit.save(service_id: test_setup[:service_id],
+                    plan_id: test_setup[:plan_id],
+                    metric_id: metric_at_top[:id],
+                    day: daily_limit)
+
+    usage_to_report = 10
+    current_time = Time.now.utc
+    seconds_remaining_day = (Period::Day.new(current_time).finish - current_time).ceil
+
+    Timecop.freeze(Time.now.utc) do
+      get '/transactions/oauth_authorize.xml',
+          { provider_key: test_setup[:provider_key],
+            app_id: test_setup[:app_id],
+            usage: { metric_at_bottom[:name] => usage_to_report }
+          },
+          'HTTP_3SCALE_OPTIONS' => Extensions::LIMIT_HEADERS
+    end
+
+    assert_equal daily_limit/usage_to_report,
+                 last_response.header['3scale-limit-remaining']
+
+    assert_equal seconds_remaining_day,
+                 last_response.header['3scale-limit-reset']
+
+    assert_equal daily_limit,
+                 last_response.header['3scale-limit-max-value']
+  end
 end

--- a/test/test_helpers/fixtures.rb
+++ b/test/test_helpers/fixtures.rb
@@ -216,7 +216,7 @@ module TestHelpers
     # Returns a hash with provider_key, service_id, app_id and metrics. metrics
     # is an ordered array where the pos 0 represents the metric in the highest
     # level of the hierarchy. Each metric has: id, name, and limit.
-    def setup_service_with_metric_hierarchy(levels, oauth: false)
+    def setup_service_with_metric_hierarchy(levels, set_limits: true, oauth: false)
       provider_key = next_id
       service_id = next_id
       Service.save!(provider_key: provider_key,
@@ -247,17 +247,20 @@ module TestHelpers
       end
       current.save if current # save() stores all the children recursively
 
-      metrics_attrs.each do |metric|
-        UsageLimit.save(service_id: service_id,
-                        plan_id: plan_id,
-                        metric_id: metric[:id],
-                        day: metric[:limit])
+      if set_limits
+        metrics_attrs.each do |metric|
+          UsageLimit.save(service_id: service_id,
+                          plan_id: plan_id,
+                          metric_id: metric[:id],
+                          day: metric[:limit])
+        end
       end
 
       {
         provider_key: provider_key,
         service_id: service_id,
         app_id: app_id,
+        plan_id: plan_id,
         metrics: metrics_attrs
       }
     end

--- a/test/unit/metric_test.rb
+++ b/test/unit/metric_test.rb
@@ -261,4 +261,17 @@ class MetricTest < Test::Unit::TestCase
       descendants.sort == metrics[idx+1..-1].map(&:name).sort
     end
   end
+
+  def test_ascendants
+    service_id = next_id
+    Service.save!(provider_key: 'a_provider_key', id: service_id)
+    levels = rand(3..10)
+    metrics = gen_hierarchy_one_metric_per_level(service_id, levels)
+
+    assert_true metrics.each_with_index.all? do |metric, idx|
+      ascendants = Metric.ascendants(service_id, metric.name)
+
+      ascendants.sort == metrics.take(idx).(&:name).sort
+    end
+  end
 end


### PR DESCRIPTION
This is part of #114 . It adapts the limits header extension to work with metric hierarchies of more than 2 levels.