### PR TITLE
usage: avoid creating unnecessary instance periods

### DIFF
--- a/lib/3scale/backend/period/period.rb
+++ b/lib/3scale/backend/period/period.rb
@@ -197,6 +197,10 @@ module ThreeScale
           ts ? klass.new(ts) : klass
         end
 
+        def instance_periods_for_ts(timestamp)
+          Hash.new { |hash, period| hash[period] = period.new(timestamp) }
+        end
+
         alias_method :[], :from
 
         include HelperMethods


### PR DESCRIPTION
This PR introduces a performance optimization in the part of the code that calculates the current usage.

This is important for users with lots of metrics and limits. Without this, the code can generate many instance periods and it ends up consuming a significant part of the total CPU time.