### PR TITLE
Worker metrics tests: check if Errno::ENETUNREACH is raised

### DIFF
--- a/spec/integration/worker_metrics_spec.rb
+++ b/spec/integration/worker_metrics_spec.rb
@@ -96,7 +96,7 @@ apisonator_worker_job_runtime_seconds_count{type="ReportJob"} \d+\.\d+
           sleep(1) # The web server takes a bit to start
 
           expect { Net::HTTP.get('localhost', metrics_endpoint, metrics_port) }
-                 .to raise_error(Errno::EADDRNOTAVAIL)
+            .to raise_error(SystemCallError)
         end
       end
 


### PR DESCRIPTION
This PR fixes one of the tests of the worker metrics server.

We've seen that both `Errno::ENETUNREACH` and `Errno::EADDRNOTAVAIL` can be raised depending on the environment, but only the first was being considered.

/cc @gsaslis 