### PR TITLE
Update rubyzip to v2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
-    rubyzip (1.2.3)
+    rubyzip (2.0.0)
     scientist (1.0.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -161,7 +161,7 @@ GEM
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
-    rubyzip (1.2.3)
+    rubyzip (2.0.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2019-16892

Does not affect in production because this is a dependency of license-finder