### PR TITLE
Make Rake tasks compatible with the async redis client

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -246,7 +246,14 @@ end
 
 desc 'Reschedule failed jobs'
 task :reschedule_failed_jobs do
-  result = ThreeScale::Backend::FailedJobsScheduler.reschedule_failed_jobs
+  reschedule_method = ThreeScale::Backend::FailedJobsScheduler.method(:reschedule_failed_jobs)
+
+  result = if Environment.using_async_redis?
+             Async { reschedule_method.call }.result
+           else
+             reschedule_method.call
+           end
+
   puts "Rescheduled: #{result[:rescheduled]}. "\
        "Failed and discarded: #{result[:failed_while_rescheduling]}. "\
        "Pending failed jobs: #{result[:failed_current]}."

--- a/lib/3scale/backend/storage_async/client.rb
+++ b/lib/3scale/backend/storage_async/client.rb
@@ -86,6 +86,7 @@ module ThreeScale
           :lrange,
           :ltrim,
           :mget,
+          :ping,
           :rpush,
           :scard,
           :setex,

--- a/lib/3scale/tasks/helpers/environment.rb
+++ b/lib/3scale/tasks/helpers/environment.rb
@@ -13,6 +13,10 @@ module ThreeScale
         def saas?
           ThreeScale::Backend.configuration.saas
         end
+
+        def using_async_redis?
+          ThreeScale::Backend.configuration.redis.async
+        end
       end
     end
   end


### PR DESCRIPTION
There are a couple of Rake tasks that were not working correctly when using the async redis client: reschedule of failed jobs and the connectivity checks.