### PR TITLE
Make async params configurable via ENV in docker images

### DIFF
--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -58,4 +58,7 @@ ThreeScale::Backend.configure do |config|
   config.workers_logger_formatter = "#{ENV['CONFIG_WORKERS_LOGGER_FORMATTER']}".to_sym
   config.worker_prometheus_metrics.enabled = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true' ? true : false
   config.worker_prometheus_metrics.port = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_PORT']
+  config.async_worker.max_concurrent_jobs = parse_int_env('CONFIG_ASYNC_WORKER_MAX_CONCURRENT_JOBS')
+  config.async_worker.max_pending_jobs = parse_int_env('CONFIG_ASYNC_WORKER_MAX_PENDING_JOBS')
+  config.async_worker.seconds_before_fetching_more = parse_int_env('CONFIG_ASYNC_WORKER_WAIT_SECONDS_FETCHING')
 end


### PR DESCRIPTION
The params are these 3:
https://github.com/3scale/apisonator/blob/24dc0c4ed02fccba226bafe516ae2c9b140a889d/lib/3scale/backend/configuration.rb#L67