### PR TITLE
Support docker-compatible CLIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 IMAGE_REPO = quay.io/3scale
 CI_IMAGE = $(IMAGE_REPO)/apisonator-ci
+DOCKER ?= $(shell which podman 2> /dev/null || which docker 2> /dev/null || echo "docker")
 
 .PHONY: default
 default: test
@@ -14,27 +15,27 @@ test: export CONTAINER_NAME?=apisonator-test
 test: DOCKER_OPTS?=
 test:
 	make -C $(PROJECT_PATH) -f $(MKFILE_PATH) dev-build
-	docker run --rm -t -h $(CONTAINER_NAME) -v \
-		$(PROJECT_PATH):$$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'cd && pwd')/apisonator:z \
-		-u $$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'id -u'):$$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'id -g') \
+	$(DOCKER) run --rm -t -h $(CONTAINER_NAME) -v \
+		$(PROJECT_PATH):$$($(DOCKER) run --rm $(IMAGE_NAME) /bin/bash -c 'cd && pwd')/apisonator:z \
+		-u $$($(DOCKER) run --rm $(IMAGE_NAME) /bin/bash -c 'id -u'):$$($(DOCKER) run --rm $(IMAGE_NAME) /bin/bash -c 'id -g') \
 	$(DOCKER_OPTS) --name $(CONTAINER_NAME) $(IMAGE_NAME)
 
 .PHONY: dev-clean
 dev-clean: CONTAINER_NAME=apisonator-dev
 dev-clean:
-	-docker kill $(CONTAINER_NAME)
-	-docker rm $(CONTAINER_NAME)
+	-$(DOCKER) kill $(CONTAINER_NAME)
+	-$(DOCKER) rm $(CONTAINER_NAME)
 
 .PHONY: dev-service-clean
 dev-service-clean: CONTAINER_NAME=apisonator-dev-service
 dev-service-clean:
-	-docker kill $(CONTAINER_NAME)
-	-docker rm $(CONTAINER_NAME)
+	-$(DOCKER) kill $(CONTAINER_NAME)
+	-$(DOCKER) rm $(CONTAINER_NAME)
 
 .PHONY: dev-clean-image
 dev-clean-image: IMAGE_NAME?=apisonator-dev
 dev-clean-image: dev-clean dev-service-clean
-	docker rmi $(IMAGE_NAME)
+	$(DOCKER) rmi $(IMAGE_NAME)
 
 .PHONY: dev
 dev: export IMAGE_NAME?=apisonator-dev
@@ -42,16 +43,16 @@ dev: export PORT?= 3000
 dev: export CONTAINER_NAME?=apisonator-dev
 dev: export COMMAND?=/bin/bash
 dev:
-	@docker history -q $(IMAGE_NAME) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) dev-build
-	@if docker ps --filter name=$(CONTAINER_NAME) --format "{{.Names}}" | grep -q '^$(CONTAINER_NAME)$$' 2> /dev/null >&2; then \
+	@$(DOCKER) history -q $(IMAGE_NAME) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) dev-build
+	@if $(DOCKER) ps --filter name=$(CONTAINER_NAME) --format "{{.Names}}" | grep -q '^$(CONTAINER_NAME)$$' 2> /dev/null >&2; then \
 		echo "$(CONTAINER_NAME) container already started" >&2; false ; \
 	fi
-	@if docker ps -a --filter name=$(CONTAINER_NAME) --format "{{.Names}}" | grep -q '^$(CONTAINER_NAME)$$' 2> /dev/null >&2; then \
-		docker start -ai $(CONTAINER_NAME) ; \
+	@if $(DOCKER) ps -a --filter name=$(CONTAINER_NAME) --format "{{.Names}}" | grep -q '^$(CONTAINER_NAME)$$' 2> /dev/null >&2; then \
+		$(DOCKER) start -ai $(CONTAINER_NAME) ; \
 	else \
-		docker run -ti -h $(CONTAINER_NAME) --expose=3000 -p $(PORT):3000 -v \
-		$(PROJECT_PATH):$$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'cd && pwd')/apisonator:z \
-		-u $$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'id -u'):$$(docker run --rm $(IMAGE_NAME) /bin/bash -c 'id -g') \
+		$(DOCKER) run -ti -h $(CONTAINER_NAME) --expose=3000 -p $(PORT):3000 -v \
+		$(PROJECT_PATH):$$($(DOCKER) run --rm $(IMAGE_NAME) /bin/bash -c 'cd && pwd')/apisonator:z \
+		-u $$($(DOCKER) run --rm $(IMAGE_NAME) /bin/bash -c 'id -u'):$$($(DOCKER) run --rm $(IMAGE_NAME) /bin/bash -c 'id -g') \
 		--name $(CONTAINER_NAME) $(IMAGE_NAME) $(COMMAND) ; \
 	fi
 
@@ -66,34 +67,34 @@ dev-build: export BUILD_CI?=0
 dev-build: export DEV_TOOLS?="vim"
 dev-build: export IMAGE_NAME?=apisonator-dev
 dev-build: $(PROJECT_PATH)/Dockerfile
-	docker history -q $(CI_IMAGE) || \
-		(test "x${BUILD_CI}" != "x1" && docker pull $(CI_IMAGE)) || \
+	$(DOCKER) history -q $(CI_IMAGE) || \
+		(test "x${BUILD_CI}" != "x1" && $(DOCKER) pull $(CI_IMAGE)) || \
 		$(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) ci-build
-	docker build -t $(IMAGE_NAME) --build-arg DEV_TOOLS=$(DEV_TOOLS) --build-arg \
-		APP_HOME="$$(docker run --rm $(CI_IMAGE) /bin/bash -c 'cd && pwd')/apisonator" \
+	$(DOCKER) build -t $(IMAGE_NAME) --build-arg DEV_TOOLS=$(DEV_TOOLS) --build-arg \
+		APP_HOME="$$($(DOCKER) run --rm $(CI_IMAGE) /bin/bash -c 'cd && pwd')/apisonator" \
 		$(PROJECT_PATH)
 
 .PHONY: ci-build
-ci-build: export APISONATOR_REL?=v$(shell docker run --rm -w /tmp/apisonator -v $(PROJECT_PATH):/tmp/apisonator:z \
+ci-build: export APISONATOR_REL?=v$(shell $(DOCKER) run --rm -w /tmp/apisonator -v $(PROJECT_PATH):/tmp/apisonator:z \
 	$(CI_IMAGE) ruby -r/tmp/apisonator/lib/3scale/backend/version -e "puts ThreeScale::Backend::VERSION")
 ci-build: $(PROJECT_PATH)/Dockerfile.ci
-	docker build -t apisonator-ci-layered:$(APISONATOR_REL) -f Dockerfile.ci $(PROJECT_PATH)
-	docker tag apisonator-ci-layered:$(APISONATOR_REL) apisonator-ci-layered:latest
+	$(DOCKER) build -t apisonator-ci-layered:$(APISONATOR_REL) -f Dockerfile.ci $(PROJECT_PATH)
+	$(DOCKER) tag apisonator-ci-layered:$(APISONATOR_REL) apisonator-ci-layered:latest
 	$(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) ci-flatten
 
 .PHONY: ci-flatten
-ci-flatten: APISONATOR_REL?=v$(shell docker run --rm -w /tmp/apisonator -v $(PROJECT_PATH):/tmp/apisonator:z \
+ci-flatten: APISONATOR_REL?=v$(shell $(DOCKER) run --rm -w /tmp/apisonator -v $(PROJECT_PATH):/tmp/apisonator:z \
 	$(CI_IMAGE) ruby -r/tmp/apisonator/lib/3scale/backend/version -e "puts ThreeScale::Backend::VERSION")
-ci-flatten: CI_USER?=$(shell docker run --rm apisonator-ci-layered:$(APISONATOR_REL) whoami)
-ci-flatten: CI_PATH?=$(shell docker run --rm apisonator-ci-layered:$(APISONATOR_REL) /bin/bash -c "echo \$${PATH}")
+ci-flatten: CI_USER?=$(shell $(DOCKER) run --rm apisonator-ci-layered:$(APISONATOR_REL) whoami)
+ci-flatten: CI_PATH?=$(shell $(DOCKER) run --rm apisonator-ci-layered:$(APISONATOR_REL) /bin/bash -c "echo \$${PATH}")
 ci-flatten:
-	-docker rm dummy-export-apisonator-ci-$(APISONATOR_REL)
-	docker run --name dummy-export-apisonator-ci-$(APISONATOR_REL) \
+	-$(DOCKER) rm dummy-export-apisonator-ci-$(APISONATOR_REL)
+	$(DOCKER) run --name dummy-export-apisonator-ci-$(APISONATOR_REL) \
 		apisonator-ci-layered:$(APISONATOR_REL) echo
-	(docker export dummy-export-apisonator-ci-$(APISONATOR_REL) | \
-		docker import -c "USER $(CI_USER)" -c "ENV PATH $(CI_PATH)" - \
+	($(DOCKER) export dummy-export-apisonator-ci-$(APISONATOR_REL) | \
+		$(DOCKER) import -c "USER $(CI_USER)" -c "ENV PATH $(CI_PATH)" - \
 		$(CI_IMAGE):$(APISONATOR_REL)) || \
 		(echo Failed to flatten image && \
-		docker rm dummy-export-apisonator-ci-$(APISONATOR_REL) && false)
-	-docker rm dummy-export-apisonator-ci-$(APISONATOR_REL)
-	docker tag $(CI_IMAGE):$(APISONATOR_REL) $(CI_IMAGE):latest
+		$(DOCKER) rm dummy-export-apisonator-ci-$(APISONATOR_REL) && false)
+	-$(DOCKER) rm dummy-export-apisonator-ci-$(APISONATOR_REL)
+	$(DOCKER) tag $(CI_IMAGE):$(APISONATOR_REL) $(CI_IMAGE):latest


### PR DESCRIPTION
This lets you define the DOCKER variable to specify a docker
compatible CLI, and in addition defaults to looks up podman in
$PATH, falling back to docker otherwise, either by full path or by
the plain "docker" name.