### PR TITLE
Introduce "flat_usage" extension

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -14,6 +14,27 @@ Such extensions can be used as specified in the API Extensions RFC.
 
 ## List of supported extensions
 
+### flat_usage (integer)
+
+This extension applies to the usage data passed in to any call that accepts
+usages. It instructs the software to _assume_ that the client has computed the
+relations between the usage methods so that, ie. if method `m` is a parent of
+method/metric `n`, then any reported hit to `n` has been added to `m`, which in
+turn should also be present in the usage specified by the client. Note that
+failing to compute this properly will result in data that does not make sense,
+such as having a limited parent with a children that goes over the parent
+limits.
+
+#### Accepted values
+
+- 0: disable the extension (default)
+- 1: enable the extension, blindly trust the specified usage values (unsafe)
+
+Values over 1 are currently undefined, but in the future could provide some
+checking to ensure data is consistent, ie. usage data with `n` incremented in
+5 necessarily means `n` parent, if existing, should be specified with a minimum
+of 5, not counting any other potential children.
+
 ### no_body (boolean)
 
 This instructs the software to avoid generating response bodies for certain endpoints.

--- a/lib/3scale/backend/error_storage.rb
+++ b/lib/3scale/backend/error_storage.rb
@@ -8,11 +8,12 @@ module ThreeScale
       MAX_NUM_ERRORS = 1000
 
       def store(service_id, error, context_info = {})
+        request_info = context_info[:request] || {}
         storage.lpush(queue_key(service_id),
                       encode(code:         error.code,
                              message:      error.message,
                              timestamp:    Time.now.getutc.to_s,
-                             context_info: context_info))
+                             context_info: request_info))
         storage.ltrim(queue_key(service_id), 0, MAX_NUM_ERRORS - 1)
       end
 

--- a/lib/3scale/backend/listener.rb
+++ b/lib/3scale/backend/listener.rb
@@ -174,7 +174,7 @@ module ThreeScale
         # not null/empty.
         params[:provider_key] = provider_key
 
-        auth_status = Transactor.send method_name, provider_key, params, threescale_extensions
+        auth_status = Transactor.send method_name, provider_key, params, request: request_info
         response_auth_call(auth_status)
       rescue ThreeScale::Backend::Error => error
         begin
@@ -610,6 +610,7 @@ module ThreeScale
           ip: request.ip,
           content_type: request.content_type,
           content_length: request.content_length,
+          extensions: threescale_extensions,
         }
       end
 

--- a/lib/3scale/backend/metric/collection.rb
+++ b/lib/3scale/backend/metric/collection.rb
@@ -24,10 +24,10 @@ module ThreeScale
         #
         #   {1001 => 42, 1002 => 42}
         #
-        def process_usage(raw_usage)
+        def process_usage(raw_usage, flat_usage = false)
           return {} unless raw_usage
           usage = parse_usage(raw_usage)
-          process_parents(usage)
+          flat_usage ? usage : process_parents(usage)
         end
 
         private

--- a/lib/3scale/backend/transactor.rb
+++ b/lib/3scale/backend/transactor.rb
@@ -24,20 +24,20 @@ module ThreeScale
         notify_report(provider_key, transactions.size)
       end
 
-      def authorize(provider_key, params, extensions = {})
-        do_authorize :authorize, provider_key, params, extensions
+      def authorize(provider_key, params, context_info = {})
+        do_authorize :authorize, provider_key, params, context_info
       end
 
-      def oauth_authorize(provider_key, params, extensions = {})
-        do_authorize :oauth_authorize, provider_key, params, extensions
+      def oauth_authorize(provider_key, params, context_info = {})
+        do_authorize :oauth_authorize, provider_key, params, context_info
       end
 
-      def authrep(provider_key, params, extensions = {})
-        do_authrep :authrep, provider_key, params, extensions
+      def authrep(provider_key, params, context_info = {})
+        do_authrep :authrep, provider_key, params, context_info
       end
 
-      def oauth_authrep(provider_key, params, extensions = {})
-        do_authrep :oauth_authrep, provider_key, params, extensions
+      def oauth_authrep(provider_key, params, context_info = {})
+        do_authrep :oauth_authrep, provider_key, params, context_info
       end
 
       def utilization(service_id, application_id)
@@ -53,7 +53,7 @@ module ThreeScale
 
       private
 
-      def validate(oauth, provider_key, report_usage, params, extensions)
+      def validate(oauth, provider_key, report_usage, params, request_info)
         service = Service.load_with_provider_key!(params[:service_id], provider_key)
         # service_id cannot be taken from params since it might be missing there
         service_id = service.id
@@ -89,6 +89,7 @@ module ThreeScale
                                                           params[:user_key])
         now          = Time.now.getutc
         usage_values = Usage.application_usage(application, now)
+        extensions   = request_info && request_info[:extensions] || {}
         status_attrs = {
           service_id:      service_id,
           application:     application,
@@ -126,14 +127,15 @@ module ThreeScale
         app_id
       end
 
-      def do_authorize(method, provider_key, params, extensions)
+      def do_authorize(method, provider_key, params, context_info)
         notify_authorize(provider_key)
-        validate(method == :oauth_authorize, provider_key, false, params, extensions)
+        validate(method == :oauth_authorize, provider_key, false, params, context_info[:request])
       end
 
-      def do_authrep(method, provider_key, params, extensions)
+      def do_authrep(method, provider_key, params, context_info)
+        request_info = context_info[:request] || {}
         status = begin
-                   validate(method == :oauth_authrep, provider_key, true, params, extensions)
+                   validate(method == :oauth_authrep, provider_key, true, params, request_info)
                  rescue ApplicationNotFound => e
                    # we still want to track these
                    notify_authorize(provider_key)

--- a/lib/3scale/backend/transactor.rb
+++ b/lib/3scale/backend/transactor.rb
@@ -100,7 +100,8 @@ module ThreeScale
           # hierarchy parameter adds information in the response needed
           # to derive which limits affect directly or indirectly the
           # metrics for which authorization is requested.
-          hierarchy:       extensions[:hierarchy] == '1'
+          hierarchy:       extensions[:hierarchy] == '1',
+          flat_usage:      extensions[:flat_usage] == '1'
         }
 
         application.load_metric_names
@@ -146,7 +147,7 @@ module ThreeScale
 
         if (usage || params[:log]) && status.authorized?
           application_id = status.application.id
-          report_enqueue(status.service_id, ({ 0 => {"app_id" => application_id, "usage" => usage, "log" => params[:log]}}), {})
+          report_enqueue(status.service_id, { 0 => {"app_id" => application_id, "usage" => usage, "log" => params[:log] } }, request: { extensions: request_info[:extensions] })
           notify_authrep(provider_key, usage ? 1 : 0)
         else
           notify_authorize(provider_key)

--- a/lib/3scale/backend/transactor/status.rb
+++ b/lib/3scale/backend/transactor/status.rb
@@ -18,6 +18,7 @@ module ThreeScale
           @values          = filter_values(attributes[:values] || {})
           @timestamp       = attributes[:timestamp] || Time.now.getutc
           @hierarchy_ext   = attributes[:hierarchy]
+          @flat_usage_ext  = attributes[:flat_usage]
 
           raise 'service_id not specified' if @service_id.nil?
           raise ':application is required' if @application.nil?
@@ -31,6 +32,10 @@ module ThreeScale
         attr_reader :oauth
         attr_accessor :redirect_uri_field
         attr_accessor :values
+
+        def flat_usage
+          @flat_usage_ext
+        end
 
         def reject!(error)
           @authorized = false

--- a/lib/3scale/backend/validators/limits.rb
+++ b/lib/3scale/backend/validators/limits.rb
@@ -12,7 +12,7 @@ module ThreeScale
         def process(values, raw_usage)
           if raw_usage
             metrics = Metric.load_all(status.service_id)
-            usage   = metrics.process_usage(raw_usage)
+            usage   = metrics.process_usage(raw_usage, status.flat_usage)
             values  = filter_metrics(values, usage.keys)
             values  = increment_or_set(values, usage)
           end

--- a/lib/3scale/backend/validators/limits.rb
+++ b/lib/3scale/backend/validators/limits.rb
@@ -4,7 +4,7 @@ module ThreeScale
       class Limits < Base
 
         def apply
-          valid_limits_app? ? succeed! : fail!(LimitsExceeded.new)
+          valid_limits? ? succeed! : fail!(LimitsExceeded.new)
         end
 
         private
@@ -20,13 +20,11 @@ module ThreeScale
           values
         end
 
-        def valid_limits_app?
-          valid_limits?(status.values, status.application.usage_limits)
-        end
-
-        def valid_limits?(values, limits)
-          processed_values = process(values, params[:usage])
-          limits.all? { |limit| limit.validate(processed_values) }
+        def valid_limits?
+          processed_values = process(status.values, params[:usage])
+          status.application.usage_limits.all? do |limit|
+            limit.validate(processed_values)
+          end
         end
 
         def filter_metrics(values, metric_ids)

--- a/test/integration/oauth/basic_test.rb
+++ b/test/integration/oauth/basic_test.rb
@@ -592,7 +592,7 @@ class OauthBasicTest < Test::Unit::TestCase
     # We have 1 parent metric and 2 children metrics, one of them limited.
     # When we add usage over the "hits" limit for the unlimited metric, we
     # should see an auth denied, and also children information in the hits usage
-    # report (and none elsewhere).
+    # report (and none elsewhere), unless we use the "flat_usage" extension.
 
     Timecop.freeze(Time.utc(2010, 5, 15)) do
       get '/transactions/oauth_authorize.xml', {
@@ -647,6 +647,55 @@ class OauthBasicTest < Test::Unit::TestCase
 
       assert_not_authorized
       assertions.call false
+
+      # Test that hitting children over the parent limit does not translate to
+      # the parent so that the call is still authorized.
+      get '/transactions/oauth_authorize.xml', {
+          :provider_key => @provider_key,
+          :app_id       => application.id,
+          :usage        => { metric_child2 => parent_limit + 1 },
+        },
+        'HTTP_3SCALE_OPTIONS' => Extensions::FLAT_USAGE
+      Resque.run!
+
+      assert_authorized
+      assertions.call false
+      #
+      get '/transactions/oauth_authorize.xml', {
+          :provider_key => @provider_key,
+          :app_id       => application.id,
+          :usage        => { metric_child1 => parent_limit + 1,
+                             metric_child2 => parent_limit + 1 },
+        },
+        'HTTP_3SCALE_OPTIONS' => Extensions::FLAT_USAGE
+      Resque.run!
+
+      assert_authorized
+      assertions.call false
+
+      # Using flat usage still goes over the limits of specified metrics
+      get '/transactions/oauth_authorize.xml', {
+          :provider_key => @provider_key,
+          :app_id       => application.id,
+          :usage        => { parent => parent_limit + 1 },
+        },
+        'HTTP_3SCALE_OPTIONS' => Extensions::FLAT_USAGE
+      Resque.run!
+
+      assert_not_authorized
+      assertions.call false
+
+      get '/transactions/oauth_authorize.xml', {
+          :provider_key => @provider_key,
+          :app_id       => application.id,
+          :usage        => { metric_child1 => parent_limit + 1 + 1 },
+        },
+        'HTTP_3SCALE_OPTIONS' => Extensions::FLAT_USAGE
+      Resque.run!
+
+      assert_not_authorized
+      assertions.call false
+
     end
   end
 end

--- a/test/test_helpers/extensions.rb
+++ b/test/test_helpers/extensions.rb
@@ -10,6 +10,7 @@ module TestHelpers
       REJECTION_REASON_HEADER = URI.encode('rejection_reason_header=1').freeze
       HIERARCHY = URI.encode('hierarchy=1').freeze
       LIMIT_HEADERS = URI.encode('limit_headers=1').freeze
+      FLAT_USAGE = URI.encode('flat_usage=1').freeze
     end
 
     module ClassMethods

--- a/test/unit/metric/collection_test.rb
+++ b/test/unit/metric/collection_test.rb
@@ -68,27 +68,26 @@ module Metric
       metric = Metric.new(:service_id => 1001, :id => 2001, :name => 'hits')
       metric.children << Metric.new(:id => 2002, :name => 'search_queries')
       metric.save
-      
+
       metrics = Metric::Collection.new(1001)
 
       assert_equal({'2001' => 1, '2002' => 1}, metrics.process_usage('search_queries' => 1))
     end
-    
+
     def test_process_usage_handles_hierarchical_metrics_with_set_values
       metric = Metric.new(:service_id => 1001, :id => 2001, :name => 'hits')
       metric.children << Metric.new(:id => 2002, :name => 'hits_child_1')
       metric.children << Metric.new(:id => 2003, :name => 'hits_child_2')
       metric.save
-      
+
       metrics = Metric::Collection.new(1001)
 
       assert_equal({'2001' => 5, '2002' => 2, '2003' => 3}, metrics.process_usage('hits_child_1' => 2, 'hits_child_2' => 3))
       assert_equal({'2001' => 11, '2002' => 2, '2003' => 3}, metrics.process_usage('hits' => 6, 'hits_child_1' => 2, 'hits_child_2' => 3))
-      
+
       assert_equal({'2001' => '#6'}, metrics.process_usage('hits' => '#6'))
       assert_equal({'2001' => '#6', '2002' => '#6'}, metrics.process_usage('hits_child_1' => '#6'))
       assert_equal({'2001' => '#11', '2002' => '#6', '2003' => '#11'}, metrics.process_usage('hits_child_1' => '#6', 'hits_child_2' => '#11'))
-            
     end
 
     def test_process_usage_handles_hierarchies_with_more_than_2_levels

--- a/test/unit/transactor/report_job_test.rb
+++ b/test/unit/transactor/report_job_test.rb
@@ -21,7 +21,9 @@ module Transactor
         with([{:service_id     => @service_id,
                :application_id => @application_id,
                :timestamp      => nil,
-               :usage          => {@metric_id => 1}}])
+               :usage          => {@metric_id => 1}}],
+               {},
+             )
 
       Transactor::ReportJob.perform(
         @service_id, {'0' => {'app_id' => @application_id, 'usage' => {'hits' => 1}}}, Time.now.getutc.to_f, @context_info)
@@ -33,8 +35,8 @@ module Transactor
       Transactor::ReportJob.perform(
         @service_id, {'0' => {'app_id' => @application_id, 'usage' => {'hits' => 1}},
                       '1' => {'app_id' => 'boo',           'usage' => {'hits' => 1}}},
-                     @context_info,
-                     Time.now.getutc.to_f)
+                     Time.now.getutc.to_f,
+                     @context_info)
     end
 
     test 'does not process any transaction if at least one has invalid metric' do
@@ -43,8 +45,8 @@ module Transactor
       Transactor::ReportJob.perform(
         @service_id, {'0' => {'app_id' => @application_id, 'usage' => {'hits' => 1}},
                       '1' => {'app_id' => @application_id, 'usage' => {'foos' => 1}}},
-                     @context_info,
-                     Time.now.getutc.to_f)
+                     Time.now.getutc.to_f,
+                     @context_info)
     end
 
     test 'does not process any transaction if at least one has invalid usage value' do
@@ -53,8 +55,8 @@ module Transactor
       Transactor::ReportJob.perform(
         @service_id, {'0' => {'app_id' => @application_id, 'usage' => {'hits' => 1}},
                       '1' => {'app_id' => @application_id, 'usage' => {'hits' => 'a lot!'}}},
-                     @context_info,
-                     Time.now.getutc.to_f)
+                     Time.now.getutc.to_f,
+                     @context_info)
     end
 
     test 'does not process any transaction if no usage is defined' do
@@ -119,7 +121,9 @@ module Transactor
         with([{:service_id     => @service_id,
                :application_id => @application_id,
                :timestamp      => nil,
-               :usage          => {@metric_id => 1}}])
+               :usage          => {@metric_id => 1}}],
+               {},
+            )
 
       Transactor::ReportJob.perform(
         @service_id, {'0' => {'user_key' => user_key, 'usage' => {'hits' => 1}}}, Time.now.getutc.to_f, @context_info)


### PR DESCRIPTION
This introduces the `flat_usage` extension. It is used to disregard hierarchy information when processing methods/metrics. The assumption is that the client _takes responsibility_, ie. `"I know what I'm doing"`, on computing how metrics have been affected taking the hierarchy in consideration, and Apisonator just processes the given usage data as if metrics had no parents.

This is very _useful for caching_, as caches need to report changes in metrics back to Apisonator after some time, but that implies having to undo the work Apisonator will do to add values from children metrics to parent metrics, because such caches already need to compute these relationships to be able to authorize their own clients.

Closes #140.

We could potentially add different levels for the value taken by this extension so we would run sanity checks and refuse to process the usage data if such checks fail, but the potential benefits are marginal given this is mostly meant to be used with reporting calls (which we don't check at request time, and doing this would mean checking at that time to avoid clients flushing their usage data).

PS. we should document the `hierarchy` extension.
PS2. the name is not really set on stone, suggestions welcome.