### PR TITLE
Update rack to 2.0.8

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -55,7 +55,7 @@ gem 'builder', '= 3.2.3'
 gem 'redis', '= 4.1.1'
 # Use a patched resque to allow reusing their Airbrake Failure class
 gem 'resque', git: 'https://github.com/3scale/resque', branch: '3scale'
-gem 'rack', '~> 2.0.6'
+gem 'rack', '~> 2.0.8'
 gem 'sinatra', '~> 2.0.3'
 gem 'sinatra-contrib', '~> 2.0.3'
 # Optional external error logging services

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       pry (~> 0.9)
       yard (~> 0.9)
     quantile (0.2.1)
-    rack (2.0.6)
+    rack (2.0.8)
     rack-protection (2.0.3)
       rack
     rack-test (0.8.2)
@@ -249,7 +249,7 @@ DEPENDENCIES
   pry-byebug (~> 3.5.1)
   pry-doc (~> 0.11.1)
   puma!
-  rack (~> 2.0.6)
+  rack (~> 2.0.8)
   rack-test (~> 0.8.2)
   rake (= 10.4.2)
   redis (= 4.1.1)

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -123,7 +123,7 @@ GEM
       pry (~> 0.9)
       yard (~> 0.9)
     quantile (0.2.1)
-    rack (2.0.6)
+    rack (2.0.8)
     rack-protection (2.0.3)
       rack
     rack-test (0.8.2)
@@ -230,7 +230,7 @@ DEPENDENCIES
   pry-byebug (~> 3.5.1)
   pry-doc (~> 0.11.1)
   puma!
-  rack (~> 2.0.6)
+  rack (~> 2.0.8)
   rack-test (~> 0.8.2)
   rake (= 10.4.2)
   redis (= 4.1.1)


### PR DESCRIPTION
Apisonator is not affected, but this update addresses this CVE: https://github.com/advisories/GHSA-hrqr-hxpp-chr3