### PR TITLE
Monkey-patch Resque.enqueue when using async

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -84,3 +84,6 @@ with the async client because of this. It's in the specs for `EventStorage` and
 its context is `with multiple calls at the same moment (race condition)`.
 
 - Cannot use Redis logical databases. See [issue #135](https://github.com/3scale/apisonator/issues/135)
+
+- We need to monkey-patch `Resque.enqueue` of the Resque lib. See the
+`Backend::StorageAsync::ResqueExtensions` module for more details.

--- a/lib/3scale/backend.rb
+++ b/lib/3scale/backend.rb
@@ -61,3 +61,8 @@ Resque.redis = ThreeScale::Backend::QueueStorage.connection(
   ThreeScale::Backend.environment,
   ThreeScale::Backend.configuration,
 )
+
+# Need to monkey-patch Resque when using async
+if ThreeScale::Backend.configuration.redis.async
+  Resque.extend ThreeScale::Backend::StorageAsync::ResqueExtensions
+end

--- a/lib/3scale/backend/storage_async.rb
+++ b/lib/3scale/backend/storage_async.rb
@@ -1,3 +1,4 @@
 require '3scale/backend/storage_async/client'
 require '3scale/backend/storage_async/pipeline'
 require '3scale/backend/storage_async/async_redis'
+require '3scale/backend/storage_async/resque_extensions'

--- a/lib/3scale/backend/storage_async/resque_extensions.rb
+++ b/lib/3scale/backend/storage_async/resque_extensions.rb
@@ -1,0 +1,30 @@
+# The async lib does not work well with the Resque gem. It crashes when running
+# a pipeline in the enqueue method.
+# This module mokey-patches that method.
+
+module ThreeScale
+  module Backend
+    module StorageAsync
+      module ResqueExtensions
+        def enqueue(klass, *args)
+          queue = queue_from_class(klass)
+
+          # The redis client is hidden inside a data store that contains a
+          # namespace that contains the redis client. Both vars are called
+          # "redis".
+          async_client = Resque.redis.instance_variable_get(:@redis).instance_variable_get(:@redis)
+
+          # We need to add the "resque" namespace in the keys for all the
+          # commands.
+          async_client.pipelined do
+            async_client.sadd('resque:queues', queue.to_s)
+            async_client.rpush(
+              "resque:queue:#{queue}", Resque.encode(:class => klass.to_s, :args => args)
+            )
+          end
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
The async lib does not work well with the Resque gem. It crashes when running a pipeline in the enqueue method. This PR mokey-patches that method when using async.

I tried running the listeners with [Falcon](https://github.com/socketry/falcon) and the change introduced in this PR is the only one needed to make it work. After applying this change, the listeners can be executed with Falcon and the async redis lib with:
`CONFIG_REDIS_ASYNC=true bundle exec falcon serve -b http://0.0.0.0:3000 -c config.ru -n 4`