### PR TITLE
stats/cleaner: handle invalid keys

### DIFF
--- a/lib/3scale/backend/stats/cleaner.rb
+++ b/lib/3scale/backend/stats/cleaner.rb
@@ -81,6 +81,8 @@ module ThreeScale
             end
 
             remove_services_from_delete_set(services)
+
+            logger.info("Finished deleting the stats keys for these services: #{services.to_a}")
           end
 
           private

--- a/lib/3scale/backend/stats/cleaner.rb
+++ b/lib/3scale/backend/stats/cleaner.rb
@@ -76,11 +76,13 @@ module ThreeScale
             services = services_to_delete
             logger.info("Going to delete the stats keys for these services: #{services.to_a}")
 
-            redis_conns.each do |redis_conn|
-              delete_keys(redis_conn, services, log_deleted_keys)
-            end
+            unless services.empty?
+              redis_conns.each do |redis_conn|
+                delete_keys(redis_conn, services, log_deleted_keys)
+              end
 
-            remove_services_from_delete_set(services)
+              remove_services_from_delete_set(services)
+            end
 
             logger.info("Finished deleting the stats keys for these services: #{services.to_a}")
           end

--- a/spec/unit/stats/cleaner_spec.rb
+++ b/spec/unit/stats/cleaner_spec.rb
@@ -109,6 +109,15 @@ module ThreeScale
             # Non-stats keys
             k1: 'v1', k2: 'v2', k3: 'v3',
 
+            # Starts with "stats/" but it's not a stats key, it's used for the
+            # "first traffic" event.
+            'stats/{service:s1}/cinstances' => 'some_val',
+
+            # Legacy or corrupted keys that look like stats keys but should be
+            # ignored.
+            'stats/{service:s1}/city:/metric:m1/day:20191216' => 1, # 'city' no longer used
+            'stats/{service:s1}/%?!`:m1/day:20191216' => 2, # corrupted.
+
             # Stats keys, service level
             'stats/{service:s1}/metric:m1/day:20191216' => 10,
             'stats/{service:s1}/metric:m1/year:20190101' => 100,


### PR DESCRIPTION
Fixes a minor bug in the `Stats::Cleaner` class. We need to handle invalid keys including corrupted ones or using a format that we no longer use.

While at it, added a couple of minor improvements.