### PR TITLE
backend-cron: fix crash when RESCHEDULE_JOBS_FREQ is defined

### DIFF
--- a/openshift/backend-cron
+++ b/openshift/backend-cron
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-reschedule_jobs_freq = ENV['RESCHEDULE_JOBS_FREQ'] || 300
+reschedule_jobs_freq = (ENV['RESCHEDULE_JOBS_FREQ'] || 300).to_i
 loop do
   system('rake', '--trace=stdout', 'reschedule_failed_jobs') or raise 'task crashed'
   ENV['ONCE'] ? exit : sleep(reschedule_jobs_freq)


### PR DESCRIPTION
When `RESCHEDULE_JOBS_FREQ` is set we need to convert it to an int, because sleep() raises if it receives a string.