### PR TITLE
Gemfile{,.on_prem}.lock: update Nokogiri to 1.10.8

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -17,7 +17,7 @@ end
 group :test do
   gem 'benchmark-ips', '~> 2.7.2'
   gem 'mocha',         '~> 1.3'
-  gem 'nokogiri',      '~> 1.10.4'
+  gem 'nokogiri',      '~> 1.10.8'
   gem 'pkg-config',    '~> 1.1.7'
   gem 'rack-test',     '~> 0.8.2'
   gem 'resque_unit',   '~> 0.4.4', source: 'https://rubygems.org'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
     nio4r (2.5.2)
-    nokogiri (1.10.4)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     parslet (1.8.2)
     pg (0.20.0)
@@ -282,7 +282,7 @@ DEPENDENCIES
   hiredis (= 0.6.1)
   license_finder (~> 5)
   mocha (~> 1.3)
-  nokogiri (~> 1.10.4)
+  nokogiri (~> 1.10.8)
   pg (= 0.20.0)
   pkg-config (~> 1.1.7)
   prometheus-client

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -128,7 +128,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
     nio4r (2.5.2)
-    nokogiri (1.10.4)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     parslet (1.8.2)
     pkg-config (1.1.9)


### PR DESCRIPTION
We are not obviously affected by the CVEs, but updating nonetheless.