### PR TITLE
Transactions with UNIX timestamps

### DIFF
--- a/docs/active_docs/Service Management API (on-premises).json
+++ b/docs/active_docs/Service Management API (on-premises).json
@@ -576,7 +576,7 @@
                   "dataType": "string",
                   "required": false,
                   "paramType": "query",
-                  "description": "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00",
+                  "description": "If passed, it should be the time when the transaction took place. Format: Either a UNIX UTC timestamp (seconds from the UNIX Epoch), or YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00.",
                   "description_inline": true
                 },
                 {
@@ -669,7 +669,7 @@
                   "dataType": "string",
                   "required": false,
                   "paramType": "query",
-                  "description": "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00",
+                  "description": "If passed, it should be the time when the transaction took place. Format: Either a UNIX UTC timestamp (seconds from the UNIX Epoch), or YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00.",
                   "description_inline": true
                 },
                 {
@@ -762,7 +762,7 @@
                   "dataType": "string",
                   "required": false,
                   "paramType": "query",
-                  "description": "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00",
+                  "description": "If passed, it should be the time when the transaction took place. Format: Either a UNIX UTC timestamp (seconds from the UNIX Epoch), or YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00.",
                   "description_inline": true
                 },
                 {

--- a/docs/active_docs/Service Management API.json
+++ b/docs/active_docs/Service Management API.json
@@ -576,7 +576,7 @@
                   "dataType": "string",
                   "required": false,
                   "paramType": "query",
-                  "description": "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00",
+                  "description": "If passed, it should be the time when the transaction took place. Format: Either a UNIX UTC timestamp (seconds from the UNIX Epoch), or YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00.",
                   "description_inline": true
                 },
                 {
@@ -669,7 +669,7 @@
                   "dataType": "string",
                   "required": false,
                   "paramType": "query",
-                  "description": "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00",
+                  "description": "If passed, it should be the time when the transaction took place. Format: Either a UNIX UTC timestamp (seconds from the UNIX Epoch), or YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00.",
                   "description_inline": true
                 },
                 {
@@ -762,7 +762,7 @@
                   "dataType": "string",
                   "required": false,
                   "paramType": "query",
-                  "description": "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00",
+                  "description": "If passed, it should be the time when the transaction took place. Format: Either a UNIX UTC timestamp (seconds from the UNIX Epoch), or YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00.",
                   "description_inline": true
                 },
                 {

--- a/lib/3scale/backend/listener.rb
+++ b/lib/3scale/backend/listener.rb
@@ -72,7 +72,7 @@ module ThreeScale
       ##~ @parameter_usage_predicted["parameters"] << @parameter_usage_fields
       ##
       ##~ @timestamp = {"name" => "timestamp", "dataType" => "string", "required" => false, "paramType" => "query"}
-      ##~ @timestamp["description"] = "If passed, it should be the time when the transaction took place. Format: YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00"
+      ##~ @timestamp["description"] = "If passed, it should be the time when the transaction took place. Format: Either a UNIX UTC timestamp (seconds from the UNIX Epoch), or YYYY-MM-DD HH:MM:SS for UTC, add -HH:MM or +HH:MM for time offset. For instance, 2011-12-30 22:15:31 -08:00."
       ##~ @timestamp["description_inline"] = true
       ##
       ##~ @parameter_log = {"name" => "log", "dataType" => "hash", "required" => false, "paramType" => "query", "allowMultiple" => false}

--- a/test/unit/extensions/time_test.rb
+++ b/test/unit/extensions/time_test.rb
@@ -191,6 +191,14 @@ module Extensions
       assert_nil Time.parse_to_utc('2012garbage2012')
     end
 
+    # FIXME: the current parsing of timestamps for dates is not well validated and takes some clearly
+    # invalud input as some date (depending on contents) due to the usage of Date._parse.
+    def test_parse_to_utc_returns_nil_on_obviously_invalid_input_it_used_to_swallow
+      pend 'Time.parse_to_utc validation failure, see https://github.com/3scale/apisonator/pull/167#issuecomment-597586622' do
+        assert_nil Time.parse_to_utc('201210garbage201210')
+      end
+    end
+
     def test_beginning_of_bucket
       assert_equal '20091103123456', Time.utc(2009, 11,  3, 12, 34, 56).beginning_of_bucket(1).to_not_compact_s
       assert_equal '20091103123456', Time.utc(2009, 11,  3, 12, 34, 56).beginning_of_bucket(2).to_not_compact_s

--- a/test/unit/extensions/time_test.rb
+++ b/test/unit/extensions/time_test.rb
@@ -182,12 +182,13 @@ module Extensions
     def test_parse_to_utc_returns_nil_on_invalid_input
       assert_nil Time.parse_to_utc(nil)
       assert_nil Time.parse_to_utc('')
-      assert_nil Time.parse_to_utc(0)
       assert_nil Time.parse_to_utc({:a => 10})
-      assert_nil Time.parse_to_utc('0')
+      assert_nil Time.parse_to_utc('0x')
+      assert_nil Time.parse_to_utc('x0')
       assert_nil Time.parse_to_utc('2011/11')
       assert_nil Time.parse_to_utc('2011/18/20')
       assert_nil Time.parse_to_utc('choke on this!')
+      assert_nil Time.parse_to_utc('2012garbage2012')
     end
 
     def test_beginning_of_bucket


### PR DESCRIPTION
This adds support for specifying transaction timestamps as UNIX Epoch timestamps, ie. number of seconds since Jan 1, 1970.