### PR TITLE
Update yabeda-prometheus to v0.5.0

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -60,7 +60,6 @@ gem 'sinatra', '~> 2.0.3'
 gem 'sinatra-contrib', '~> 2.0.3'
 # Optional external error logging services
 gem 'bugsnag', '~> 6', require: nil
-gem 'prometheus-client'
-gem 'yabeda-prometheus', '= 0.1.4'
+gem 'yabeda-prometheus', '~> 0.5.0'
 gem 'async-redis', '~> 0.4.1'
 gem 'falcon', '~> 0.34'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     daemons (1.2.4)
     diff-lcs (1.3)
     docile (1.1.5)
-    dry-initializer (3.0.1)
+    dry-initializer (3.0.3)
     falcon (0.34.5)
       async (~> 1.13)
       async-container (~> 0.14.0)
@@ -152,8 +152,7 @@ GEM
       process-terminal (~> 0.2.0)
     process-terminal (0.2.0)
       ffi
-    prometheus-client (0.9.0)
-      quantile (~> 0.2.1)
+    prometheus-client (1.0.0)
     protocol-hpack (1.4.1)
     protocol-http (0.13.0)
     protocol-http1 (0.10.0)
@@ -171,7 +170,6 @@ GEM
     pry-doc (0.11.1)
       pry (~> 0.9)
       yard (~> 0.9)
-    quantile (0.2.1)
     rack (2.0.8)
     rack-protection (2.0.3)
       rack
@@ -254,11 +252,12 @@ GEM
       chronic (>= 0.6.3)
     with_env (1.1.0)
     xml-simple (1.1.5)
-    yabeda (0.1.3)
+    yabeda (0.5.0)
       concurrent-ruby
       dry-initializer
-    yabeda-prometheus (0.1.4)
-      yabeda
+    yabeda-prometheus (0.5.0)
+      prometheus-client (~> 1.0)
+      yabeda (~> 0.5)
     yajl-ruby (1.3.1)
     yard (0.9.20)
 
@@ -285,7 +284,6 @@ DEPENDENCIES
   nokogiri (~> 1.10.8)
   pg (= 0.20.0)
   pkg-config (~> 1.1.7)
-  prometheus-client
   pry (~> 0.11.3)
   pry-byebug (~> 3.5.1)
   pry-doc (~> 0.11.1)
@@ -308,7 +306,7 @@ DEPENDENCIES
   test-unit (~> 3.2.6)
   timecop (~> 0.9.1)
   whenever (= 0.9.7)
-  yabeda-prometheus (= 0.1.4)
+  yabeda-prometheus (~> 0.5.0)
   yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -77,7 +77,7 @@ GEM
     daemons (1.2.4)
     diff-lcs (1.3)
     docile (1.1.5)
-    dry-initializer (3.0.1)
+    dry-initializer (3.0.3)
     falcon (0.34.3)
       async (~> 1.13)
       async-container (~> 0.14.0)
@@ -137,8 +137,7 @@ GEM
       process-terminal (~> 0.2.0)
     process-terminal (0.2.0)
       ffi
-    prometheus-client (0.9.0)
-      quantile (~> 0.2.1)
+    prometheus-client (1.0.0)
     protocol-hpack (1.4.1)
     protocol-http (0.12.3)
     protocol-http1 (0.9.0)
@@ -156,7 +155,6 @@ GEM
     pry-doc (0.11.1)
       pry (~> 0.9)
       yard (~> 0.9)
-    quantile (0.2.1)
     rack (2.0.8)
     rack-protection (2.0.3)
       rack
@@ -235,11 +233,12 @@ GEM
       rack (>= 1.0.0)
     with_env (1.1.0)
     xml-simple (1.1.5)
-    yabeda (0.1.3)
+    yabeda (0.5.0)
       concurrent-ruby
       dry-initializer
-    yabeda-prometheus (0.1.4)
-      yabeda
+    yabeda-prometheus (0.5.0)
+      prometheus-client (~> 1.0)
+      yabeda (~> 0.5)
     yajl-ruby (1.3.1)
     yard (0.9.20)
 
@@ -263,7 +262,6 @@ DEPENDENCIES
   mocha (~> 1.3)
   nokogiri (~> 1.10.8)
   pkg-config (~> 1.1.7)
-  prometheus-client
   pry (~> 0.11.3)
   pry-byebug (~> 3.5.1)
   pry-doc (~> 0.11.1)
@@ -283,7 +281,7 @@ DEPENDENCIES
   sshkit
   test-unit (~> 3.2.6)
   timecop (~> 0.9.1)
-  yabeda-prometheus (= 0.1.4)
+  yabeda-prometheus (~> 0.5.0)
   yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH

--- a/lib/3scale/backend/worker_metrics.rb
+++ b/lib/3scale/backend/worker_metrics.rb
@@ -2,15 +2,20 @@ require 'yabeda/prometheus'
 
 Yabeda.configure do
   group :apisonator_worker do
-    counter :job_count, comment: "Total number of jobs processed"
+    counter :job_count do
+      comment "Total number of jobs processed"
+      tags %i[type]
+    end
 
     histogram :job_runtime do
       comment "How long jobs take to run"
       unit :seconds
+      tags %i[type]
       buckets [0.005, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
     end
   end
 end
+Yabeda.configure!
 
 module ThreeScale
   module Backend

--- a/spec/integration/worker_metrics_spec.rb
+++ b/spec/integration/worker_metrics_spec.rb
@@ -55,7 +55,7 @@ module ThreeScale
           expect(resp).to match(
 /TYPE apisonator_worker_job_count counter
 # HELP apisonator_worker_job_count Total number of jobs processed
-apisonator_worker_job_count{type="ReportJob"} #{n_jobs}
+apisonator_worker_job_count{type="ReportJob"} #{n_jobs}(\.0)?
 # TYPE apisonator_worker_job_runtime_seconds histogram
 # HELP apisonator_worker_job_runtime_seconds How long jobs take to run
 .*


### PR DESCRIPTION
This PR updates the yabeda-prometheus gem to the latest version available. The new version has support for multi-process web servers, which we need to add metrics for the listener.