### PR TITLE
Add Prometheus metrics for the listener

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -43,7 +43,7 @@ group :development, :test do
 end
 
 # Default server by platform
-gem 'puma', git: 'https://github.com/3scale/puma', ref: '9b17499eeb491ab951e519f48416540629d085ec'
+gem 'puma', git: 'https://github.com/3scale/puma', ref: 'b034371406690d3e6c2a9301c4a48bd721f3efc3'
 # gems required by the runner
 gem 'gli', '~> 2.16.1', require: nil
 # Workers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/3scale/puma
-  revision: 9b17499eeb491ab951e519f48416540629d085ec
-  ref: 9b17499eeb491ab951e519f48416540629d085ec
+  revision: b034371406690d3e6c2a9301c4a48bd721f3efc3
+  ref: b034371406690d3e6c2a9301c4a48bd721f3efc3
   specs:
     puma (2.15.3)
 

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/3scale/puma
-  revision: 9b17499eeb491ab951e519f48416540629d085ec
-  ref: 9b17499eeb491ab951e519f48416540629d085ec
+  revision: b034371406690d3e6c2a9301c4a48bd721f3efc3
+  ref: b034371406690d3e6c2a9301c4a48bd721f3efc3
   specs:
     puma (2.15.3)
 

--- a/Rakefile
+++ b/Rakefile
@@ -68,7 +68,9 @@ if Environment.saas?
     end
 
     require 'rspec/core/rake_task'
-    spec_task_dependencies = ['spec:unit', 'spec:integration', 'spec:acceptance', 'spec:api', 'spec:use_cases']
+    spec_task_dependencies = [
+      'spec:unit', 'spec:integration', 'spec:acceptance', 'spec:api', 'spec:use_cases', 'spec:server'
+    ]
 
     desc 'Run RSpec tests'
     task :spec => spec_task_dependencies
@@ -76,7 +78,7 @@ if Environment.saas?
     namespace :spec do
 
       require 'rspec/core/rake_task'
-      desc 'Run all RSpec tests (unit, integration, acceptance, api, use_cases)'
+      desc 'Run all RSpec tests (unit, integration, acceptance, api, use_cases, server)'
       task :all => spec_task_dependencies
 
       desc 'Run RSpec unit tests'
@@ -108,6 +110,12 @@ if Environment.saas?
       desc 'Run RSpec use_cases tests'
       RSpec::Core::RakeTask.new(:use_cases) do |task|
         task.pattern = 'spec/use_cases/**/*_spec.rb'
+        task.rspec_opts = '--require=spec_helper'
+      end
+
+      desc 'Run Rspec server tests'
+      RSpec::Core::RakeTask.new(:server) do |task|
+        task.pattern = 'spec/server/**/*_spec.rb'
         task.rspec_opts = '--require=spec_helper'
       end
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -186,3 +186,12 @@ tag ''
 # activate_control_app 'unix:///var/run/pumactl.sock'
 # activate_control_app 'unix:///var/run/pumactl.sock', { auth_token: '12345' }
 # activate_control_app 'unix:///var/run/pumactl.sock', { no_token: true }
+
+before_fork do
+  # Config is not loaded at this point, so read ENV instead.
+  if ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true'
+    require_relative '../lib/3scale/backend/listener_metrics'
+    prometheus_port = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_PORT']
+    ThreeScale::Backend::ListenerMetrics.start_metrics_server(prometheus_port)
+  end
+end

--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -1,6 +1,8 @@
 # Prometheus metrics
 
-| Metric                                | Description                        | Type      | Labels                           |
-|---------------------------------------|------------------------------------|-----------|----------------------------------|
-| apisonator_worker_job_count           | Number of jobs processed           | counter   | type(ReportJob, NotifyJob, etc.) |
-| apisonator_worker_job_runtime_seconds | How long the jobs take to complete | histogram | type(ReportJob, NotifyJob, etc.) |
+| Metric                                | Type      | Labels                                                                       | Description                                 |
+|---------------------------------------|-----------|------------------------------------------------------------------------------|---------------------------------------------|
+| apisonator_listener_response_times    | histogram | request_type(authorize, authrep, report)                                     | Request response times in seconds           |
+| apisonator_listener_response_codes    | counter   | request_type(authorize, authrep, report), resp_code(2xx, 403, 404, 409, 5xx) | HTTP status codes returned by the listeners |
+| apisonator_worker_job_count           | counter   | type(ReportJob, NotifyJob, etc.)                                             | Number of jobs processed                    |
+| apisonator_worker_job_runtime_seconds | histogram | type(ReportJob, NotifyJob, etc.)                                             | How long the jobs take to complete          |

--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -60,6 +60,7 @@ module ThreeScale
       config.add_section(:oauth, :max_token_size)
       config.add_section(:master, :metrics)
       config.add_section(:worker_prometheus_metrics, :enabled, :port)
+      config.add_section(:listener_prometheus_metrics, :enabled, :port)
 
       config.add_section(
           :async_worker,

--- a/lib/3scale/backend/listener_metrics.rb
+++ b/lib/3scale/backend/listener_metrics.rb
@@ -1,0 +1,99 @@
+require 'yabeda/prometheus'
+require 'rack'
+
+module ThreeScale
+  module Backend
+    class ListenerMetrics
+      REQUEST_TYPES = {
+        '/transactions/authorize.xml' => 'authorize',
+        '/transactions/oauth_authorize.xml' => 'authorize_oauth',
+        '/transactions/authrep.xml' => 'authrep',
+        '/transactions/oauth_authrep.xml' => 'authrep_oauth',
+        '/transactions.xml' => 'report'
+      }
+      private_constant :REQUEST_TYPES
+
+      class << self
+        ERRORS_4XX_TO_TRACK = Set[403, 404, 409].freeze
+        private_constant :ERRORS_4XX_TO_TRACK
+
+        def start_metrics_server(port = nil)
+          configure_data_store
+          define_metrics
+
+          # Yabeda does not accept the port as a param
+          ENV['PROMETHEUS_EXPORTER_PORT'] = port.to_s if port
+          Yabeda::Prometheus::Exporter.start_metrics_server!
+        end
+
+        def report_resp_code(path, resp_code)
+          Yabeda.apisonator_listener.response_codes.increment(
+            {
+              request_type: REQUEST_TYPES[path],
+              resp_code: code_group(resp_code)
+            },
+            by: 1
+          )
+        end
+
+        def report_response_time(path, request_time)
+          Yabeda.apisonator_listener.response_times.measure(
+            { request_type: REQUEST_TYPES[path] },
+            request_time
+          )
+        end
+
+        private
+
+        def configure_data_store
+          # Needed to aggregate metrics across processes.
+          # Ref: https://github.com/yabeda-rb/yabeda-prometheus#multi-process-server-support
+          Dir['/tmp/prometheus/*.bin'].each do |file_path|
+            File.unlink(file_path)
+          end
+
+          Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(
+            dir: '/tmp/prometheus'
+          )
+        end
+
+        def define_metrics
+          Yabeda.configure do
+            group :apisonator_listener do
+              counter :response_codes do
+                comment 'Response codes'
+                tags %i[request_type resp_code]
+              end
+
+              histogram :response_times do
+                comment 'Response times'
+                unit :seconds
+                tags %i[request_type]
+                # Most requests will be under 100ms, so use a higher granularity from there
+                buckets [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.25, 0.5, 0.75, 1]
+              end
+            end
+          end
+
+          # Note that this method raises if called more than once. Both
+          # listeners and workers define their metrics, but that's fine because
+          # a process cannot act as both.
+          Yabeda.configure!
+        end
+
+        def code_group(resp_code)
+          case resp_code
+          when (200...300)
+            '2xx'.freeze
+          when (400...500)
+            ERRORS_4XX_TO_TRACK.include?(resp_code) ? resp_code : '4xx'.freeze
+          when (500...600)
+            '5xx'.freeze
+          else
+            'unknown'.freeze
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale/backend/rack.rb
+++ b/lib/3scale/backend/rack.rb
@@ -2,6 +2,7 @@ require '3scale/backend/configuration'
 require '3scale/backend/logging/middleware'
 require '3scale/backend/util'
 require '3scale/backend/rack/exception_catcher'
+require '3scale/backend/rack/prometheus'
 require '3scale/backend'
 
 require 'rack'
@@ -12,6 +13,10 @@ module ThreeScale
       def self.run(rack)
         rack.instance_eval do
           Backend::Logging::External.setup_rack self
+
+          if Backend.configuration.listener_prometheus_metrics.enabled
+            use Rack::Prometheus
+          end
 
           loggers = Backend.configuration.request_loggers
           log_writers = Backend::Logging::Middleware.writers loggers

--- a/lib/3scale/backend/rack/prometheus.rb
+++ b/lib/3scale/backend/rack/prometheus.rb
@@ -1,0 +1,19 @@
+module ThreeScale
+  module Backend
+    module Rack
+      class Prometheus
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          began_at = Time.now.getutc
+          status, header, body = @app.call(env)
+          ListenerMetrics.report_resp_code(env['REQUEST_PATH'], status)
+          ListenerMetrics.report_response_time(env['REQUEST_PATH'], Time.now - began_at)
+          [status, header, body]
+        end
+      end
+    end
+  end
+end

--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -58,6 +58,8 @@ ThreeScale::Backend.configure do |config|
   config.workers_logger_formatter = "#{ENV['CONFIG_WORKERS_LOGGER_FORMATTER']}".to_sym
   config.worker_prometheus_metrics.enabled = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true' ? true : false
   config.worker_prometheus_metrics.port = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_PORT']
+  config.listener_prometheus_metrics.enabled = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true'
+  config.listener_prometheus_metrics.port = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_PORT']
   config.async_worker.max_concurrent_jobs = parse_int_env('CONFIG_ASYNC_WORKER_MAX_CONCURRENT_JOBS')
   config.async_worker.max_pending_jobs = parse_int_env('CONFIG_ASYNC_WORKER_MAX_PENDING_JOBS')
   config.async_worker.seconds_before_fetching_more = parse_int_env('CONFIG_ASYNC_WORKER_WAIT_SECONDS_FETCHING')

--- a/openshift/config/puma.rb
+++ b/openshift/config/puma.rb
@@ -186,3 +186,12 @@ tag ''
 # activate_control_app 'unix:///var/run/pumactl.sock'
 # activate_control_app 'unix:///var/run/pumactl.sock', { auth_token: '12345' }
 # activate_control_app 'unix:///var/run/pumactl.sock', { no_token: true }
+
+before_fork do
+  # Config is not loaded at this point, so read ENV instead.
+  if ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true'
+    require_relative '../lib/3scale/backend/listener_metrics'
+    prometheus_port = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_PORT']
+    ThreeScale::Backend::ListenerMetrics.start_metrics_server(prometheus_port)
+  end
+end

--- a/spec/server/listener_metrics_spec.rb
+++ b/spec/server/listener_metrics_spec.rb
@@ -1,0 +1,173 @@
+require_relative '../spec_helper'
+require 'net/http'
+require '3scale/backend'
+
+module ThreeScale
+  module Backend
+    describe Listener do
+      # The port is not the standard one to avoid clashes with other tests
+      let(:puma_port) { 4000 }
+      let(:puma_host) { 'localhost' }
+      let(:config_file) { '/tmp/.3scale_backend_listener_metrics_test.config' }
+      let(:metrics_endpoint) { '/metrics' }
+      let(:metrics_port) { 9394 }
+
+      context 'when listener metrics are enabled' do
+        let(:provider_key) { 'pk' }
+        let(:service_id) { '1' }
+        let(:app_id) { '1' }
+        let(:user_key) { 'uk' }
+        let(:metric_id) { '1' }
+        let(:metric_name) { 'hits' }
+
+        let(:args) do
+          {
+            provider_key: provider_key,
+            service_id: service_id,
+            app_id: app_id,
+            user_key: user_key,
+            metric_id: metric_id,
+            metric_name: metric_name,
+            metric_val: 1,
+          }
+        end
+
+        before do
+          write_config_file(config_file)
+          start_puma_with_metrics(config_file, puma_port, metrics_port)
+
+          ThreeScale::Backend::Service.save!(
+            provider_key: provider_key, id: service_id
+          )
+          ThreeScale::Backend::Application.save(
+            service_id: service_id, id: app_id, state: :active
+          )
+          ThreeScale::Backend::Application.save_id_by_key(
+            service_id, user_key, app_id
+          )
+          ThreeScale::Backend::Metric.save(
+            service_id: service_id, id: metric_id, name: metric_name
+          )
+
+          # Do requests to generate some metrics:
+          # - 1 authorize (authorized)
+          # - 2 authreps authorized
+          # - 2 authreps unauthorized, one that returns 403 and another that returns 404
+          do_auth(puma_host, puma_port, args)
+          2.times { do_authrep(puma_host, puma_port, args) }
+          do_authrep(puma_host, puma_port, args.merge(user_key: 'invalid')) # 403
+          do_authrep(puma_host, puma_port, args.merge(metric_name: 'invalid')) # 404
+        end
+
+        after do
+          stop_puma(puma_port)
+          delete_config_file(config_file)
+        end
+
+        it 'shows metrics in Prometheus format' do
+          metrics_resp = Net::HTTP.get(puma_host, metrics_endpoint, metrics_port)
+
+          # These are some lines that we know that should be part of the output.
+          check_lines = [
+            '# TYPE apisonator_listener_response_codes counter',
+            '# HELP apisonator_listener_response_codes Response codes',
+            'apisonator_listener_response_codes{request_type="authrep",resp_code="2xx"} 2.0',
+            'apisonator_listener_response_codes{request_type="authorize",resp_code="2xx"} 1.0',
+            'apisonator_listener_response_codes{request_type="authrep",resp_code="403"} 1.0',
+            'apisonator_listener_response_codes{request_type="authrep",resp_code="404"} 1.0',
+            '# TYPE apisonator_listener_response_times_seconds histogram',
+            '# HELP apisonator_listener_response_times_seconds Response times',
+            'apisonator_listener_response_times_seconds_count{request_type="authorize"} 1.0',
+            'apisonator_listener_response_times_seconds_count{request_type="authrep"} 4.0',
+          ]
+
+          expect(metrics_resp).to include(*check_lines)
+        end
+      end
+
+      context 'when listener metrics are not enabled' do
+        before do
+          write_config_file(config_file)
+          start_puma_without_metrics(config_file, puma_port)
+        end
+
+        after do
+          stop_puma(puma_port)
+          delete_config_file(config_file)
+        end
+
+        it 'does not open the metrics port' do
+          expect { Net::HTTP.get(puma_host, metrics_endpoint, metrics_port) }
+                 .to raise_error(Errno::EADDRNOTAVAIL)
+        end
+      end
+
+      private
+
+      def write_config_file(path)
+        File.open(path, 'w+') do |f|
+          f.write("ThreeScale::Backend.configure do |config|\n"\
+              " config.listener_prometheus_metrics.enabled = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true'\n"\
+              " config.listener_prometheus_metrics.port = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_PORT']\n"\
+              "end\n")
+        end
+      end
+
+      def delete_config_file(path)
+        File.delete(path)
+      end
+
+      def start_puma_with_metrics(config_file, puma_port, metrics_port)
+        start_puma(config_file, true, puma_port, metrics_port)
+      end
+
+      def start_puma_without_metrics(config_file, puma_port)
+        start_puma(config_file, false, puma_port, '')
+      end
+
+      def start_puma(config_file, metrics_enabled, puma_port, metrics_port)
+        envs = {
+          LISTENER_WORKERS: 2, # To check that metrics are accurate with multiple workers
+          CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED: metrics_enabled,
+          CONFIG_LISTENER_PROMETHEUS_METRICS_PORT: metrics_port,
+          CONFIG_FILE: config_file
+        }
+        envs_str = envs.map { |env, val| "#{env}=#{val}" }.join(' ')
+
+        # Send logs to /dev/null to avoid cluttering the output
+        start_ok = system("#{envs_str} bundle exec bin/3scale_backend start -p #{puma_port} > /dev/null &")
+        raise 'Failed to start Puma' unless start_ok
+        sleep(2) # Give it some time to be ready
+      end
+
+      def stop_puma(puma_port)
+        system("bundle exec bin/3scale_backend stop -p #{puma_port}")
+      end
+
+      def do_auth(puma_host, puma_port, args)
+        query = auth_query(args)
+        Net::HTTP.get(puma_host, query, puma_port)
+      end
+
+      def do_authrep(puma_host, puma_port, args)
+        query = authrep_query(args)
+        Net::HTTP.get(puma_host, query, puma_port)
+      end
+
+      def auth_query(args)
+        '/transactions/authorize.xml?' + parsed_query_args(args)
+      end
+
+      def authrep_query(args)
+        '/transactions/authrep.xml?' + parsed_query_args(args)
+      end
+
+      def parsed_query_args(args)
+        "provider_key=#{args[:provider_key]}" +
+          "&service_id=#{args[:service_id]}" +
+          "&user_key=#{args[:user_key]}" +
+          "&usage%5B#{args[:metric_name]}%5D=#{args[:metric_val]}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a couple of metrics for the listeners: a histogram for request times aggregated by request type (auth, authrep, report) and a counter for response codes aggregated by request type and code (2xx, 4xx, 5xx).

The output looks like this:
```
# TYPE apisonator_listener_response_codes counter
# HELP apisonator_listener_response_codes Response codes
apisonator_listener_response_codes{request_type="authorize",resp_code="2xx"} 1.0
apisonator_listener_response_codes{request_type="authrep",resp_code="2xx"} 2.0
apisonator_listener_response_codes{request_type="authrep",resp_code="4xx"} 1.0
# TYPE apisonator_listener_request_times_seconds histogram
# HELP apisonator_listener_request_times_seconds Request times
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.01"} 2.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.02"} 2.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.03"} 2.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.04"} 2.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.05"} 2.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.06"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.07"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.08"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.09"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.1"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.25"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.5"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="0.75"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="1"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authrep",le="+Inf"} 3.0
apisonator_listener_request_times_seconds_sum{request_type="authrep"} 0.07076911599999999
apisonator_listener_request_times_seconds_count{request_type="authrep"} 3.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.01"} 0.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.02"} 0.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.03"} 0.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.04"} 0.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.05"} 0.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.06"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.07"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.08"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.09"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.1"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.25"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.5"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="0.75"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="1"} 1.0
apisonator_listener_request_times_seconds_bucket{request_type="authorize",le="+Inf"} 1.0
apisonator_listener_request_times_seconds_sum{request_type="authorize"} 0.05043955
apisonator_listener_request_times_seconds_count{request_type="authorize"} 1.0
```

Remember that we already added metrics for the workers in #111 
Note that this PR does not configure Falcon to use metrics. I'll do that in a separate PR.