### PR TITLE
Fix start_twemproxy() function in script/lib/functions

### DIFF
--- a/script/lib/functions
+++ b/script/lib/functions
@@ -44,7 +44,14 @@ function stop_redis {
 
 function start_twemproxy {
     local basedir="${SCRIPT_DIR:-$(pwd -P)}"
-    local configdir="${basedir}/config"
+
+    local configdir
+    if [ -r ${basedir}/config/twemproxy.yml ]; then
+        configdir="${basedir}/config"
+    else
+        configdir="${basedir}/script/config"
+    fi
+
     /opt/twemproxy/sbin/nutcracker -m 512 -o /tmp/nutcracker-$(date +"%Y%m%d%H%M%S").log -p "${TWEMPROXY_PIDFILE}" -d -c ${configdir}/twemproxy.yml
 }
 


### PR DESCRIPTION
Fixes an error introduced in a previous PR: https://github.com/3scale/apisonator/pull/175

With that change, the script stopped working correctly when called from the user home in the container.