### PR TITLE
Add integration test for authrep calls that report a response code

### DIFF
--- a/test/integration/authrep/response_codes_test.rb
+++ b/test/integration/authrep/response_codes_test.rb
@@ -5,6 +5,7 @@ class AuthRepResponseCodesTest < Test::Unit::TestCase
   include TestHelpers::Fixtures
   include TestHelpers::Integration
   include TestHelpers::AuthRep
+  include TestHelpers::StorageKeys
 
   def setup
     @storage = Storage.instance(true)
@@ -23,6 +24,25 @@ class AuthRepResponseCodesTest < Test::Unit::TestCase
 
     @metric_id = next_id
     Metric.save(service_id: @service.id, id: @metric_id, name: 'hits')
+  end
+
+  test_authrep 'can report response codes' do |e|
+    current_time = Time.utc(2020, 1, 1)
+
+    Timecop.freeze(current_time) do
+      get e, {
+        provider_key: @provider_key,
+        app_id: @application.id,
+        usage: { 'hits' => 1 },
+        log: { code: 200 }
+      }
+
+      Resque.run!
+    end
+
+    assert_equal 200, last_response.status
+    assert_equal '1', @storage.get(response_code_key(@service_id, '200', :day, '20200101'))
+    assert_equal '1', @storage.get(response_code_key(@service_id, '2XX', :day, '20200101'))
   end
 
   test_authrep 'no longer supported log attrs (request, response) are ignored in report jobs' do |e|


### PR DESCRIPTION
This PR adds an integration test for an authrep call that reports a response code.
While working on my previous PR I realized that we had this kind of test for the report endpoint, but not for the authrep ones.