### PR TITLE
Fix concurrency issue in BackgroundJob

### DIFF
--- a/lib/3scale/backend/background_job.rb
+++ b/lib/3scale/backend/background_job.rb
@@ -9,11 +9,10 @@ module ThreeScale
 
       class << self
         def perform(*args)
-          @args = args
-          perform_wrapper
+          perform_wrapper(args)
         end
 
-        def perform_logged
+        def perform_logged(*_args)
           raise "This should be overloaded."
         end
 
@@ -25,13 +24,13 @@ module ThreeScale
 
         private
 
-        def enqueue_time
-          @args.last or raise('Enqueue time not specified')
+        def enqueue_time(args)
+          args.last or raise('Enqueue time not specified')
         end
 
-        def perform_wrapper
+        def perform_wrapper(args)
           start_time = Time.now.getutc
-          status_ok, message = perform_logged(*@args)
+          status_ok, message = perform_logged(*args)
           stats_mem = Memoizer.stats
           end_time = Time.now.getutc
 
@@ -41,7 +40,7 @@ module ThreeScale
           if status_ok
             Worker.logger.info(prefix +
               " #{(end_time - start_time).round(5)}" +
-              " #{(end_time.to_f - enqueue_time).round(5)}"+
+              " #{(end_time.to_f - enqueue_time(args)).round(5)}"+
               " #{stats_mem[:size]} #{stats_mem[:count]} #{stats_mem[:hits]}")
 
             if configuration.worker_prometheus_metrics.enabled

--- a/lib/3scale/backend/stats/partition_eraser_job.rb
+++ b/lib/3scale/backend/stats/partition_eraser_job.rb
@@ -48,8 +48,8 @@ module ThreeScale
             end
           end
 
-          def enqueue_time
-            @args[0]
+          def enqueue_time(args)
+            args[0]
           end
         end
       end

--- a/lib/3scale/backend/stats/partition_generator_job.rb
+++ b/lib/3scale/backend/stats/partition_generator_job.rb
@@ -36,8 +36,8 @@ module ThreeScale
 
           private
 
-          def enqueue_time
-            @args[0]
+          def enqueue_time(args)
+            args[0]
           end
         end
       end

--- a/lib/3scale/backend/transactor/report_job.rb
+++ b/lib/3scale/backend/transactor/report_job.rb
@@ -32,8 +32,8 @@ module ThreeScale
 
           private
 
-          def enqueue_time
-            @args[2]
+          def enqueue_time(args)
+            args[2]
           end
 
           def parse_transactions(service_id, raw_transactions, request_info)


### PR DESCRIPTION
This PR replaces the usage of a class variable in `BackgroundJob`.

That class variable causes problems when using the async mode because fibers can modify it while others still need to read it. Luckily, with the current code, the only attribute affected is "enqueue_time", which is not accurate anyway (see https://github.com/3scale/apisonator/issues/18).

Even without taking the async mode into consideration using a class var is counter-intuitive. The arguments of a particular job (service ID, app ID, etc.) should belong to an instance, they shouldn't be stored in a class var.