### PR TITLE
Gemfiles: update hiredis to 0.6.3

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -9,7 +9,7 @@ gemspec
 # implementations (ie. pure Ruby, java, etc).
 #
 platform :ruby do
-  gem 'hiredis', '= 0.6.1'
+  gem 'hiredis', '~> 0.6.1'
   gem 'yajl-ruby', '~> 1.3.1', require: 'yajl'
   gem 'pry-byebug', '~> 3.5.1', groups: [:development]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       reentrant_flock
       sinatra (>= 1.2.7)
     gli (2.16.1)
-    hiredis (0.6.1)
+    hiredis (0.6.3)
     httpclient (2.8.3)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
@@ -284,7 +284,7 @@ DEPENDENCIES
   falcon (~> 0.35)
   geminabox (~> 0.13.11)
   gli (~> 2.16.1)
-  hiredis (= 0.6.1)
+  hiredis (~> 0.6.1)
   license_finder (~> 5)
   mocha (~> 1.3)
   nokogiri (~> 1.10.8)

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -106,7 +106,7 @@ GEM
       reentrant_flock
       sinatra (>= 1.2.7)
     gli (2.16.1)
-    hiredis (0.6.1)
+    hiredis (0.6.3)
     httpclient (2.8.3)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
@@ -266,7 +266,7 @@ DEPENDENCIES
   falcon (~> 0.35)
   geminabox (~> 0.13.11)
   gli (~> 2.16.1)
-  hiredis (= 0.6.1)
+  hiredis (~> 0.6.1)
   license_finder (~> 5)
   mocha (~> 1.3)
   nokogiri (~> 1.10.8)


### PR DESCRIPTION
Note that I've also relaxed the requirement in the Gemfile. I don't see any reason to pin this dependency to a specific version.