### PR TITLE
Adjust prometheus histogram buckets for the worker

### DIFF
--- a/lib/3scale/backend/worker_metrics.rb
+++ b/lib/3scale/backend/worker_metrics.rb
@@ -11,7 +11,8 @@ Yabeda.configure do
       comment "How long jobs take to run"
       unit :seconds
       tags %i[type]
-      buckets [0.005, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+      # Most requests will be under 100ms, so use a higher granularity from there
+      buckets [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.25, 0.5, 0.75, 1]
     end
   end
 end


### PR DESCRIPTION
The current ones are not very informative, because the majority of run times fall in the first or second bucket.