### PR TITLE
Perf optimization: load just the limits needed when no_body=true 

### DIFF
--- a/lib/3scale/backend/application.rb
+++ b/lib/3scale/backend/application.rb
@@ -223,6 +223,10 @@ module ThreeScale
         @usage_limits ||= UsageLimit.load_all(service_id, plan_id)
       end
 
+      def load_all_usage_limits
+        @usage_limits = UsageLimit.load_all(service_id, plan_id)
+      end
+
       # Loads the usage limits affected by the metrics received, that is, the
       # limits that are defined for those metrics plus all their ancestors in
       # the metrics hierarchy.

--- a/lib/3scale/backend/application.rb
+++ b/lib/3scale/backend/application.rb
@@ -223,6 +223,20 @@ module ThreeScale
         @usage_limits ||= UsageLimit.load_all(service_id, plan_id)
       end
 
+      # Loads the usage limits affected by the metrics received, that is, the
+      # limits that are defined for those metrics plus all their ancestors in
+      # the metrics hierarchy.
+      def load_usage_limits_affected_by(metric_names)
+        metric_ids = metric_names.flat_map do |name|
+          [name] + Metric.ascendants(service_id, name)
+        end.uniq.map do |name|
+          Metric.load_id(service_id, name)
+        end
+
+        # IDs are sorted to be able to use the memoizer
+        @usage_limits = UsageLimit.load_for_affecting_metrics(service_id, plan_id, metric_ids.sort)
+      end
+
       def active?
         state == :active
       end

--- a/test/integration/authrep/basic_test.rb
+++ b/test/integration/authrep/basic_test.rb
@@ -428,6 +428,36 @@ class AuthrepBasicTest < Test::Unit::TestCase
     assert_equal '', last_response.body
   end
 
+  test_authrep 'a request without "no_body" works as expected after making a request with "no_body"' do |e|
+    # A call with no_body enabled only loads the limits that affect the metrics
+    # of the request. This test checks that all the limits appear in the XML of
+    # a subsequent call.
+
+    UsageLimit.save(
+      service_id: @service_id, plan_id: @plan_id, metric_id: @metric_id, day: 10
+    )
+
+    other_metric_id = next_id
+    Metric.save(service_id: @service_id, id: other_metric_id, name: 'some_metric')
+    UsageLimit.save(
+      service_id: @service_id, plan_id: @plan_id, metric_id: other_metric_id, day: 20
+    )
+
+    get e, { provider_key: @provider_key, app_id: @application.id },
+        'HTTP_3SCALE_OPTIONS' => Extensions::NO_BODY
+
+    assert_equal 200, last_response.status
+    assert_equal '', last_response.body
+
+    get e, { provider_key: @provider_key, app_id: @application.id }
+
+    assert_equal 200, last_response.status
+
+    doc = Nokogiri::XML(last_response.body)
+    assert_not_nil doc.at('usage_report[metric = "hits"][period = "day"]')
+    assert_not_nil doc.at('usage_report[metric = "some_metric"][period = "day"]')
+  end
+
   test_authrep 'response contains usage reports marked as exceeded on exceeded client usage limits' do |e|
     UsageLimit.save(:service_id => @service.id,
                     :plan_id    => @plan_id,

--- a/test/integration/oauth/basic_test.rb
+++ b/test/integration/oauth/basic_test.rb
@@ -269,6 +269,38 @@ class OauthBasicTest < Test::Unit::TestCase
     assert_equal '', last_response.body
   end
 
+  test 'a request without "no_body" works as expected after making a request with "no_body"' do
+    # A call with no_body enabled only loads the limits that affect the metrics
+    # of the request. This test checks that all the limits appear in the XML of
+    # a subsequent call.
+
+    UsageLimit.save(
+      service_id: @service_id, plan_id: @plan_id, metric_id: @metric_id, day: 10
+    )
+
+    other_metric_id = next_id
+    Metric.save(service_id: @service_id, id: other_metric_id, name: 'some_metric')
+    UsageLimit.save(
+      service_id: @service_id, plan_id: @plan_id, metric_id: other_metric_id, day: 20
+    )
+
+    get '/transactions/oauth_authorize.xml',
+        { provider_key: @provider_key, app_id: @application.id },
+        'HTTP_3SCALE_OPTIONS' => Extensions::NO_BODY
+
+    assert_equal 200, last_response.status
+    assert_equal '', last_response.body
+
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, app_id: @application.id }
+
+    assert_equal 200, last_response.status
+
+    doc = Nokogiri::XML(last_response.body)
+    assert_not_nil doc.at('usage_report[metric = "hits"][period = "day"]')
+    assert_not_nil doc.at('usage_report[metric = "some_metric"][period = "day"]')
+  end
+
   test 'response contains usage reports marked as exceeded on exceeded client usage limits' do
     UsageLimit.save(:service_id => @service.id,
                     :plan_id    => @plan_id,


### PR DESCRIPTION
When the `no_body` option is enabled we just need to load the usage limits that are affected by the metrics included in the usage of the request, that is, the limits defined for those metrics plus any of their ancestors in the metrics hierarchy.

When `no_body` is disabled, we need to load all the usage limits because we need to include them in the response XML.

We were not distinguishing between both cases. This PR changes the transactor so it only loads the usage limits required for the request. This can reduce a lot the number of keys that we need to fetch from redis when `no_body` is enabled and the service has many metrics defined.