### PR TITLE
Test auth/authrep with invalid metric in the usage

### DIFF
--- a/test/integration/authorize/basic_test.rb
+++ b/test/integration/authorize/basic_test.rb
@@ -768,4 +768,15 @@ class AuthorizeBasicTest < Test::Unit::TestCase
 
     assert_not_authorized
   end
+
+  test 'returns error when the usage includes a metric that does not exist' do
+    get '/transactions/authorize.xml',
+        {
+          provider_key: @provider_key,
+          app_id: @application.id,
+          usage: { 'non_existing' => 1 }
+        }
+
+    assert_error_resp_with_exc(ThreeScale::Backend::MetricInvalid.new('non_existing'))
+  end
 end

--- a/test/integration/authrep/basic_test.rb
+++ b/test/integration/authrep/basic_test.rb
@@ -957,4 +957,15 @@ class AuthrepBasicTest < Test::Unit::TestCase
     assert_equal 409, last_response.status
     assert_nil last_response.header['3scale-rejection-reason']
   end
+
+  test_authrep 'returns error when the usage includes a metric that does not exist' do |e|
+    get e,
+        {
+          provider_key: @provider_key,
+          app_id: @application.id,
+          usage: { 'non_existing' => 1 }
+        }
+
+    assert_error_resp_with_exc(ThreeScale::Backend::MetricInvalid.new('non_existing'))
+  end
 end

--- a/test/integration/oauth/basic_test.rb
+++ b/test/integration/oauth/basic_test.rb
@@ -730,4 +730,15 @@ class OauthBasicTest < Test::Unit::TestCase
 
     end
   end
+
+  test 'returns error when the usage includes a metric that does not exist' do
+    get '/transactions/oauth_authorize.xml',
+        {
+          provider_key: @provider_key,
+          app_id: @application.id,
+          usage: { 'non_existing' => 1 }
+        }
+
+    assert_error_resp_with_exc(ThreeScale::Backend::MetricInvalid.new('non_existing'))
+  end
 end


### PR DESCRIPTION
While debugging an issue introduced in my previous PR (#221) I realized that we don't have any integration tests for the auth and authrep endpoints that return "invalid_metric". This PR adds them.