### PR TITLE
Fix bug when loading the usage limits and no_body=true

### DIFF
--- a/lib/3scale/backend/application.rb
+++ b/lib/3scale/backend/application.rb
@@ -230,11 +230,12 @@ module ThreeScale
       # Loads the usage limits affected by the metrics received, that is, the
       # limits that are defined for those metrics plus all their ancestors in
       # the metrics hierarchy.
+      # Raises MetricInvalid when a metric does not exist.
       def load_usage_limits_affected_by(metric_names)
         metric_ids = metric_names.flat_map do |name|
           [name] + Metric.ascendants(service_id, name)
         end.uniq.map do |name|
-          Metric.load_id(service_id, name)
+          Metric.load_id(service_id, name) || raise(MetricInvalid.new(name))
         end
 
         # IDs are sorted to be able to use the memoizer

--- a/test/integration/authorize/basic_test.rb
+++ b/test/integration/authorize/basic_test.rb
@@ -779,4 +779,17 @@ class AuthorizeBasicTest < Test::Unit::TestCase
 
     assert_error_resp_with_exc(ThreeScale::Backend::MetricInvalid.new('non_existing'))
   end
+
+  test 'returns error when the usage includes a metric that does not exist and no_body=true' do
+    get '/transactions/authorize.xml',
+        {
+          provider_key: @provider_key,
+          app_id: @application.id,
+          usage: { 'hits' => 1, 'non_existing' => 1 }
+        },
+        'HTTP_3SCALE_OPTIONS' => Extensions::NO_BODY
+
+    assert_equal ThreeScale::Backend::MetricInvalid.new('non_existing').http_code,
+                 last_response.status
+  end
 end

--- a/test/integration/authrep/basic_test.rb
+++ b/test/integration/authrep/basic_test.rb
@@ -968,4 +968,17 @@ class AuthrepBasicTest < Test::Unit::TestCase
 
     assert_error_resp_with_exc(ThreeScale::Backend::MetricInvalid.new('non_existing'))
   end
+
+  test_authrep 'returns error when the usage includes a metric that does not exist and no_body=true' do |e|
+    get e,
+        {
+          provider_key: @provider_key,
+          app_id: @application.id,
+          usage: { 'hits' => 1, 'non_existing' => 1 }
+        },
+        'HTTP_3SCALE_OPTIONS' => Extensions::NO_BODY
+
+    assert_equal ThreeScale::Backend::MetricInvalid.new('non_existing').http_code,
+                 last_response.status
+  end
 end

--- a/test/integration/oauth/basic_test.rb
+++ b/test/integration/oauth/basic_test.rb
@@ -741,4 +741,17 @@ class OauthBasicTest < Test::Unit::TestCase
 
     assert_error_resp_with_exc(ThreeScale::Backend::MetricInvalid.new('non_existing'))
   end
+
+  test 'returns error when the usage includes a metric that does not exist and no_body=true' do
+    get '/transactions/oauth_authorize.xml',
+        {
+          provider_key: @provider_key,
+          app_id: @application.id,
+          usage: { 'hits' => 1, 'non_existing' => 1 }
+        },
+        'HTTP_3SCALE_OPTIONS' => Extensions::NO_BODY
+
+    assert_equal ThreeScale::Backend::MetricInvalid.new('non_existing').http_code,
+                 last_response.status
+  end
 end

--- a/test/unit/application_test.rb
+++ b/test/unit/application_test.rb
@@ -522,4 +522,14 @@ class ApplicationTest < Test::Unit::TestCase
     assert_equal 1, application.usage_limits.count { |limit| limit.metric_id == metric_2_id }
     assert_equal 1, application.usage_limits.count { |limit| limit.metric_id == metric_3_id }
   end
+
+  test '.load_usage_limits_affected_by raises MetricInvalid when a metric does not exist' do
+    application = Application.save(
+      service_id: '1000', id: '2000', state: :active, plan_id: '3000', plan_name: 'some_plan'
+    )
+
+    assert_raise MetricInvalid do
+      application.load_usage_limits_affected_by(['non_existing'])
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes a bug introduced in #221 

The problem is that I assumed that in `Application.load_usage_limits_affected_by` all the metrics passed were already validated, but that was a mistake because the listener does not validate the metrics until it runs the `Limits` validator, which happens later in the process.

More specificaly, when a metric does not exist, `Metric.load_id` returns nil and then, the sort here crashes:
https://github.com/3scale/apisonator/blob/e965a2228c331c21b159925d16888a5f473ef26c/lib/3scale/backend/application.rb#L241

We didn't caught this because we didn't have tests that used both `no_body=true`, and reported more than 1 metric and at least an invalid one. I have included tests for that in this PR.

In the future, maybe we should make the metrics validation more explicit as a separate test in the transactor rather than have it hidden in the `Limits` validator.