### PR TITLE
Gemfiles: update rack to 2.1.4

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -53,7 +53,7 @@ gem 'rake', '~> 13.0'
 gem 'builder', '= 3.2.3'
 # Use a patched resque to allow reusing their Airbrake Failure class
 gem 'resque', git: 'https://github.com/3scale/resque', branch: '3scale'
-gem 'rack', '~> 2.0.8'
+gem 'rack', '~> 2.1.4'
 gem 'sinatra', '~> 2.0.3'
 gem 'sinatra-contrib', '~> 2.0.3'
 # Optional external error logging services

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
     pry-doc (0.11.1)
       pry (~> 0.9)
       yard (~> 0.9)
-    rack (2.0.9)
+    rack (2.1.4)
     rack-protection (2.0.3)
       rack
     rack-test (0.8.2)
@@ -286,7 +286,7 @@ DEPENDENCIES
   pry-byebug (~> 3.5.1)
   pry-doc (~> 0.11.1)
   puma!
-  rack (~> 2.0.8)
+  rack (~> 2.1.4)
   rack-test (~> 0.8.2)
   rake (~> 13.0)
   redis!

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -159,7 +159,7 @@ GEM
     pry-doc (0.11.1)
       pry (~> 0.9)
       yard (~> 0.9)
-    rack (2.0.9)
+    rack (2.1.4)
     rack-protection (2.0.3)
       rack
     rack-test (0.8.2)
@@ -267,7 +267,7 @@ DEPENDENCIES
   pry-byebug (~> 3.5.1)
   pry-doc (~> 0.11.1)
   puma!
-  rack (~> 2.0.8)
+  rack (~> 2.1.4)
   rack-test (~> 0.8.2)
   rake (~> 13.0)
   redis!


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-j6w9-fv6q-3q52
Apisonator is not affected by the CVE.