### PR TITLE
Validate master service ID just once

### DIFF
--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -1,6 +1,7 @@
 require '3scale/backend/configuration/loader'
 require '3scale/backend/environment'
 require '3scale/backend/configurable'
+require '3scale/backend/errors'
 
 module ThreeScale
   module Backend
@@ -118,6 +119,10 @@ module ThreeScale
       config.master.metrics.transactions_authorize = config.master.metrics.transactions_authorize.to_s
       if config.master.metrics.transactions_authorize.empty?
         config.master.metrics.transactions_authorize = CONFIG_MASTER_METRICS_TRANSACTIONS_AUTHORIZE_DEFAULT
+      end
+
+      if config.master_service_id.nil? || config.master_service_id.to_s.empty?
+        raise InvalidMasterServiceId
       end
 
       # can_create_event_buckets is just for our SaaS analytics system.

--- a/lib/3scale/backend/errors.rb
+++ b/lib/3scale/backend/errors.rb
@@ -303,5 +303,12 @@ module ThreeScale
         super 'End-users are no longer supported, do not specify the user_id parameter'.freeze
       end
     end
+
+    class InvalidMasterServiceId < Error
+      def initialize
+        super "Can't find master service id. Make sure the \"master_service_id\" "\
+              'configuration value is set correctly'.freeze
+      end
+    end
   end
 end

--- a/lib/3scale/backend/transactor/notify_job.rb
+++ b/lib/3scale/backend/transactor/notify_job.rb
@@ -7,8 +7,6 @@ module ThreeScale
         extend Configurable
         @queue = :main
 
-        InvalidMasterServiceId = Class.new(ThreeScale::Backend::Error)
-
         class << self
           def perform_logged(provider_key, usage, timestamp, _enqueue_time)
             application_id = Application.load_id_by_key(master_service_id, provider_key)
@@ -29,15 +27,7 @@ module ThreeScale
           private
 
           def master_service_id
-            value = configuration.master_service_id
-
-            unless value
-              raise InvalidMasterServiceId,
-                    "Can't find master service id. Make sure the \"master_service_id\" "\
-                    'configuration value is set correctly'
-            end
-
-            value.to_s
+            configuration.master_service_id.to_s
           end
         end
       end

--- a/test/unit/transactor/notify_job_test.rb
+++ b/test/unit/transactor/notify_job_test.rb
@@ -71,16 +71,5 @@ module Transactor
         # ...
       end
     end
-
-    def test_raises_if_master_service_id_is_invalid
-      Transactor::NotifyJob.configuration.stubs(:master_service_id).returns(nil)
-
-      assert_raises Transactor::NotifyJob::InvalidMasterServiceId do
-        Transactor::NotifyJob.perform(@provider_key,
-                                      {'transactions/authorize' => 1},
-                                      Time.utc(2010, 7, 29, 18, 21),
-                                      Time.utc(2010, 7, 29, 18, 21).to_f)
-      end
-    end
   end
 end


### PR DESCRIPTION
Validate the master service ID once, instead of doing it in the notify jobs.

If the master service ID is not set, all the notify jobs will fail. It's better to detect this as soon as possible and exit.