### PR TITLE
Handle corner case with "TransactionTimestampNotWithinRange" in notify jobs

### DIFF
--- a/lib/3scale/backend/transactor/notify_job.rb
+++ b/lib/3scale/backend/transactor/notify_job.rb
@@ -14,12 +14,30 @@ module ThreeScale
             if application_id && Application.exists?(master_service_id, application_id)
               master_metrics = Metric.load_all(master_service_id)
 
-              ProcessJob.perform([{
-                service_id: master_service_id,
-                application_id: application_id,
-                timestamp: timestamp,
-                usage: master_metrics.process_usage(usage)
-              }])
+              begin
+                ProcessJob.perform([{
+                  service_id: master_service_id,
+                  application_id: application_id,
+                  timestamp: timestamp,
+                  usage: master_metrics.process_usage(usage)
+                }])
+              rescue TransactionTimestampNotWithinRange => e
+                # This is very unlikely to happen. The timestamps in a notify
+                # job are not set by users, they are set by the listeners. If
+                # this error happens it might mean that:
+                # a) The worker started processing this job way after the
+                # listener produced it. This can happen for example if we make
+                # some requests to a listener with no workers. The listeners
+                # will enqueue some notify jobs. If we start a worker hours
+                # later, we might see this error.
+                # b) There's some kind of clock skew issue.
+                # c) There's a bug.
+                #
+                # We can't raise here, because then, the job will be retried,
+                # but it's going to fail always if it has an old timestamp.
+                Worker.logger.notify(e)
+                return [false, "#{provider_key} #{application_id} #{e}"]
+              end
             end
             [true, "#{provider_key} #{application_id || '--'}"]
           end

--- a/test/unit/transactor/notify_job_test.rb
+++ b/test/unit/transactor/notify_job_test.rb
@@ -11,62 +11,71 @@ module Transactor
     end
 
     def test_processes_the_transactions
+      now = Time.now.utc
+
       Transactor::ProcessJob.expects(:perform).
         with([{:service_id     => @master_service_id,
                :application_id => @provider_application_id,
-               :timestamp      => Time.utc(2010, 7, 29, 18, 21),
+               :timestamp      => now,
                :usage          => {@master_hits_id => 1, @master_authorizes_id => 1}}])
 
       Transactor::NotifyJob.perform(@provider_key,
                                     {'transactions/authorize' => 1},
-                                    Time.utc(2010, 7, 29, 18, 21),
-                                    Time.utc(2010, 7, 29, 18, 21).to_f)
+                                    now,
+                                    now.to_f)
     end
 
     def test_does_not_raise_an_exception_if_provider_key_is_invalid
+      now = Time.now.utc
+
       assert_nothing_raised do
         Transactor::NotifyJob.perform('foo',
                                       {'transactions/authorize' => 1},
-                                      Time.utc(2010, 7, 29, 18, 21),
-                                      Time.utc(2010, 7, 29, 18, 21).to_f)
+                                      now,
+                                      now.to_f)
       end
     end
 
     def test_does_not_report_error_if_provider_key_is_invalid
+      now = Time.now.utc
       ErrorStorage.expects(:store).never
 
       Transactor::NotifyJob.perform('foo',
                                     {'transactions/authorize' => 1},
-                                    Time.utc(2010, 7, 29, 18, 21),
-                                    Time.utc(2010, 7, 29, 18, 21).to_f)
+                                    now,
+                                    now.to_f)
     end
 
     def test_does_not_process_the_transactions_if_provider_key_is_invalid
+      now = Time.now.utc
       Transactor::ProcessJob.expects(:perform).never
 
       Transactor::NotifyJob.perform('foo',
                                     {'transactions/authorize' => 1},
-                                    Time.utc(2010, 7, 29, 18, 21),
-                                    Time.utc(2010, 7, 29, 18, 21).to_f)
+                                    now,
+                                    now.to_f)
     end
 
     def test_raises_an_exception_if_metrics_are_invalid
+      now = Time.now.utc
+
       assert_raises MetricInvalid do
         Transactor::NotifyJob.perform(@provider_key,
                                       {'transactions/invalid_metric' => 1},
-                                      Time.utc(2010, 7, 29, 18, 21),
-                                      Time.utc(2010, 7, 29, 18, 21).to_f)
+                                      now,
+                                      now.to_f)
       end
     end
 
     def test_does_not_process_the_transactions_if_metrics_are_invalid
+      now = Time.now.utc
       Transactor::ProcessJob.expects(:perform).never
 
       begin
         Transactor::NotifyJob.perform(@provider_key,
                                       {'transactions/invalid_metric' => 1},
-                                      Time.utc(2010, 7, 29, 18, 21),
-                                      Time.utc(2010, 7, 29, 18, 21).to_f)
+                                      now,
+                                      now.to_f)
       rescue MetricInvalid
         # ...
       end


### PR DESCRIPTION
This handles an error that's very unlikely to happen. I think that today it's the first time I've seen this.

We were not handling `TransactionTimestampNotWithinRange` in notify jobs. At first glance, this doesn't look necessary because the timestamps in those jobs come from the listener processes and not the user. However, there are a few corner cases that make this necessary. Please check the explanation I added [here](https://github.com/3scale/apisonator/compare/notify-job-handle-timestamp-not-in-range?expand=1#diff-a1238ecbec4e11a641deb8a67f9f2a74R27).

We need to handle `TransactionTimestampNotWithinRange`, otherwise, notify jobs are re-enqueued even though they can't be processed correctly.