### PR TITLE
Run notify job only when the master service ID is explicitly defined

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
-status = ["ci/circleci"]
-pr_status = ["ci/circleci", "codeclimate"]
+status = ["ci/circleci: build"]
+pr_status = ["ci/circleci: build", "workflow", "codeclimate"]
 delete_merged_branches = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,14 +158,15 @@ send events to Porta.
 ### CONFIG_MASTER_SERVICE_ID
 
 - The service ID of the master account in Porta.
-- Optional. Defaults to 1.
-- Applies to: worker.
+- Optional. If not provided, Apisonator does not report metrics to the master
+account of Porta.
+- Applies to: listener, worker.
 - Format: string.
 
 ### CONFIG_MASTER_METRICS_TRANSACTIONS
 
-- Name of the metric configured in the master account of Porta to
-track the number of report calls.
+- Name of the metric configured in the master account of Porta to track the
+number of report calls. Applies only when `CONFIG_MASTER_SERVICE_ID` is set.
 - Optional. Defaults to "transactions".
 - Applies to: listener.
 - Format: string.
@@ -173,7 +174,7 @@ track the number of report calls.
 ### CONFIG_MASTER_METRICS_TRANSACTIONS_AUTHORIZE
 
 - Name of the metric configured in the master account of Porta to track the
-number of authorize calls.
+number of authorize calls. Applies only when `CONFIG_MASTER_SERVICE_ID` is set.
 - Optional. Defaults to "transactions/authorize".
 - Applies to: listener.
 - Format: string.

--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -22,9 +22,6 @@ module ThreeScale
       end
     end
 
-    MASTER_SERVICE_ID_DEFAULT = 1
-    private_constant :MASTER_SERVICE_ID_DEFAULT
-
     NOTIFICATION_BATCH_DEFAULT = 10000
     private_constant :NOTIFICATION_BATCH_DEFAULT
 
@@ -119,10 +116,6 @@ module ThreeScale
       config.master.metrics.transactions_authorize = config.master.metrics.transactions_authorize.to_s
       if config.master.metrics.transactions_authorize.empty?
         config.master.metrics.transactions_authorize = CONFIG_MASTER_METRICS_TRANSACTIONS_AUTHORIZE_DEFAULT
-      end
-
-      if config.master_service_id.to_s.empty?
-        config.master_service_id = MASTER_SERVICE_ID_DEFAULT
       end
 
       # can_create_event_buckets is just for our SaaS analytics system.

--- a/lib/3scale/backend/transactor/notify_batcher.rb
+++ b/lib/3scale/backend/transactor/notify_batcher.rb
@@ -30,9 +30,13 @@ module ThreeScale
         end
 
         def notify(provider_key, usage)
-          # batch several notifications together so that we can process just one
+          # We need the master service ID to report its metrics. If it's not
+          # set, we don't need to notify anything.
+          # Batch several notifications together so that we can process just one
           # job for a group of them.
-          notify_batch(provider_key, usage)
+          unless configuration.master_service_id.to_s.empty?
+            notify_batch(provider_key, usage)
+          end
         end
 
         def notify_batch(provider_key, usage)

--- a/test/test_helpers/configuration.rb
+++ b/test/test_helpers/configuration.rb
@@ -1,6 +1,7 @@
 require '3scale/backend'
 
 ThreeScale::Backend.configure do |config|
+  config.master_service_id = 1
   config.stats.bucket_size  = 5
   config.notification_batch = 5
   config.redshift.host = 'localhost'

--- a/test/unit/transactor/notify_batcher_test.rb
+++ b/test/unit/transactor/notify_batcher_test.rb
@@ -144,6 +144,24 @@ module Transactor
 
       self.configuration = bkp_configuration
     end
+
+    test 'does not batch anything when master service ID is not set' do
+      original_config = configuration.clone
+
+      [nil, ""].each do |master_service_id|
+        configuration.master_service_id = master_service_id
+
+        provider_key = 'some_provider_key'
+        Transactor.notify_authorize(provider_key)
+        Transactor.notify_authrep(provider_key, 1)
+        Transactor.notify_report(provider_key, 1)
+
+        assert_equal 0, @storage.llen(Transactor.key_for_notifications_batch) # nothing batched
+        assert_equal 0, Resque.queues[:main].size # nothing enqueued
+      end
+
+      self.configuration = original_config
+    end
   end
 end
 


### PR DESCRIPTION
This is related to the previous PR: #237 

We assumed that we could set a default for the master service ID, but after talking with the Porta team, we realized that's not a safe assumption.

This PR changes the configuration setup so it no longer sets a default for the service ID, and also runs notify jobs only when that ID has been set.