### PR TITLE
Use case insensitive strings when parsing booleans in config

### DIFF
--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -5,6 +5,11 @@ def parse_int_env(env_name)
   !env_var.nil? && !env_var.empty? ? env_var.to_i : nil
 end
 
+def parse_boolean_env(env_name)
+  value = ENV[env_name]
+  !value.nil? && value.downcase == 'true'
+end
+
 # Returns the request loggers as an array of symbols.
 # For example: [:text, :json]
 def parse_request_loggers
@@ -14,7 +19,7 @@ def parse_request_loggers
 end
 
 ThreeScale::Backend.configure do |config|
-  config.saas = ENV['CONFIG_SAAS'].to_s == 'true' ? true : false
+  config.saas = parse_boolean_env('CONFIG_SAAS')
   config.internal_api.user = "#{ENV['CONFIG_INTERNAL_API_USER']}"
   config.internal_api.password = "#{ENV['CONFIG_INTERNAL_API_PASSWORD']}"
   config.queues.master_name = "#{ENV['CONFIG_QUEUES_MASTER_NAME']}"
@@ -31,7 +36,7 @@ ThreeScale::Backend.configure do |config|
   config.redis.read_timeout = parse_int_env('CONFIG_REDIS_READ_TIMEOUT')
   config.redis.write_timeout = parse_int_env('CONFIG_REDIS_WRITE_TIMEOUT')
   config.redis.max_connections = parse_int_env('CONFIG_REDIS_MAX_CONNS')
-  config.redis.async = ENV['CONFIG_REDIS_ASYNC'].to_s == 'true' ? true : false
+  config.redis.async = parse_boolean_env('CONFIG_REDIS_ASYNC')
   config.aws_access_key_id = "#{ENV['CONFIG_AWS_ACCESS_KEY_ID']}"
   config.aws_secret_access_key = "#{ENV['CONFIG_AWS_SECRET_ACCESS_KEY']}"
   config.kinesis_stream_name = "#{ENV['CONFIG_KINESIS_STREAM_NAME']}"
@@ -41,7 +46,7 @@ ThreeScale::Backend.configure do |config|
   config.stats.delete_partition_batch_size = "#{ENV['CONFIG_DELETE_STATS_PARTITION_BATCH_SIZE']}"
   config.notification_batch = "#{ENV['CONFIG_NOTIFICATION_BATCH']}"
   config.log_path = "#{ENV['CONFIG_LOG_PATH']}"
-  config.can_create_event_buckets = ENV['CONFIG_CAN_CREATE_EVENT_BUCKETS'].to_s == 'true' ? true : false
+  config.can_create_event_buckets = parse_boolean_env('CONFIG_CAN_CREATE_EVENT_BUCKETS')
   config.redshift.host = "#{ENV['CONFIG_REDSHIFT_HOST']}"
   config.redshift.port = ENV['CONFIG_REDSHIFT_PORT']
   config.redshift.dbname = "#{ENV['CONFIG_REDSHIFT_DBNAME']}"
@@ -57,12 +62,12 @@ ThreeScale::Backend.configure do |config|
   config.workers_log_file = "#{ENV['CONFIG_WORKERS_LOG_FILE']}"
   config.request_loggers = parse_request_loggers
   config.workers_logger_formatter = "#{ENV['CONFIG_WORKERS_LOGGER_FORMATTER']}".to_sym
-  config.worker_prometheus_metrics.enabled = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true' ? true : false
+  config.worker_prometheus_metrics.enabled = parse_boolean_env('CONFIG_WORKER_PROMETHEUS_METRICS_ENABLED')
   config.worker_prometheus_metrics.port = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_PORT']
-  config.listener_prometheus_metrics.enabled = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true'
+  config.listener_prometheus_metrics.enabled = parse_boolean_env('CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED')
   config.listener_prometheus_metrics.port = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_PORT']
   config.async_worker.max_concurrent_jobs = parse_int_env('CONFIG_ASYNC_WORKER_MAX_CONCURRENT_JOBS')
   config.async_worker.max_pending_jobs = parse_int_env('CONFIG_ASYNC_WORKER_MAX_PENDING_JOBS')
   config.async_worker.seconds_before_fetching_more = parse_int_env('CONFIG_ASYNC_WORKER_WAIT_SECONDS_FETCHING')
-  config.legacy_referrer_filters = ENV['CONFIG_LEGACY_REFERRER_FILTERS'].to_s == 'true'
+  config.legacy_referrer_filters = parse_boolean_env('CONFIG_LEGACY_REFERRER_FILTERS')
 end

--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -7,7 +7,7 @@ end
 
 def parse_boolean_env(env_name)
   value = ENV[env_name]
-  !value.nil? && value.downcase == 'true'
+  value == '1'.freeze || value&.downcase == 'true'.freeze
 end
 
 # Returns the request loggers as an array of symbols.


### PR DESCRIPTION
It seems reasonable to expect that something like "True" should work the same as "true".

For example, the kubernetes libs used by our saas-operator sets booleans to "True" and "False".