### PR TITLE
Stop reporting usages of 0

### DIFF
--- a/test/integration/authrep/basic_test.rb
+++ b/test/integration/authrep/basic_test.rb
@@ -621,8 +621,6 @@ class AuthrepBasicTest < Test::Unit::TestCase
   end
 
   test_authrep 'regression test for bug on reporting hits and the method of hits at the same time' do |e|
-    # http://3scale.airbrake.io/errors/39117266
-
     @child_metric_id = next_id
 
     m1 = Metric.save(:service_id => @service.id,

--- a/test/integration/authrep/basic_test.rb
+++ b/test/integration/authrep/basic_test.rb
@@ -5,6 +5,7 @@ class AuthrepBasicTest < Test::Unit::TestCase
   include TestHelpers::Fixtures
   include TestHelpers::Integration
   include TestHelpers::Extensions
+  include TestHelpers::StorageKeys
 
   include TestHelpers::AuthRep
 
@@ -980,5 +981,51 @@ class AuthrepBasicTest < Test::Unit::TestCase
 
     assert_equal ThreeScale::Backend::MetricInvalid.new('non_existing').http_code,
                  last_response.status
+  end
+
+  test_authrep 'does not create stats keys with usage == 0' do |e|
+    hits_id = @metric_id
+    metric_name = 'some_metric'
+    metric_id = next_id
+    Metric.save(service_id: @service_id, id: metric_id, name: metric_name)
+
+    current_time = Time.now
+
+    Timecop.freeze(current_time) do
+      get e,
+          {
+            provider_key: @provider_key,
+            app_id: @application.id,
+            usage: { 'hits' => 0, metric_name => 1 }
+          }
+
+      Resque.run!
+    end
+
+    assert_equal 200, last_response.status
+
+    # 'Hits' was 0, so there shouldn't be a stats key for it.
+    hits_key_created = @storage.exists(
+      application_key(
+        @service_id,
+        @application.id,
+        hits_id,
+        :month,
+        Period::Boundary.start_of(:month, current_time.getutc).to_compact_s
+      )
+    )
+    assert_false hits_key_created
+
+    # The other metric had a non-zero usage so there should be a stats key for it.
+    # Check just the month key in this test as an example. Other tests check all
+    # the keys.
+    reported_metric_stats_key = application_key(
+      @service_id,
+      @application.id,
+      metric_id,
+      :month,
+      Period::Boundary.start_of(:month, current_time.getutc).to_compact_s
+    )
+    assert_equal 1, @storage.get(reported_metric_stats_key).to_i
   end
 end

--- a/test/integration/report_test.rb
+++ b/test/integration/report_test.rb
@@ -261,6 +261,55 @@ class ReportTest < Test::Unit::TestCase
     assert_equal 'usage value "tons!" for metric "hits" is invalid', error[:message]
   end
 
+  test 'report does not create keys with usage == 0' do
+    hits_id = @metric_id
+    metric_name = 'some_metric'
+    metric_id = next_id
+    Metric.save(service_id: @service_id, id: metric_id, name: metric_name)
+
+    current_time = Time.now
+
+    Timecop.freeze(current_time) do
+      post '/transactions.xml',
+           provider_key: @provider_key,
+           transactions: {
+             0 => {
+               app_id: @application.id,
+               usage: { 'hits' => 0, metric_name => 1 },
+               timestamp: Time.now
+             },
+           }
+
+      Resque.run!
+    end
+
+    assert_equal 202, last_response.status
+
+    # 'Hits' was 0, so there shouldn't be a stats key for it.
+    hits_key_created = @storage.exists(
+      application_key(
+        @service_id,
+        @application.id,
+        hits_id,
+        :month,
+        Period::Boundary.start_of(:month, current_time.getutc).to_compact_s
+      )
+    )
+    assert_false hits_key_created
+
+    # The other metric had a non-zero usage so there should be a stats key for it.
+    # Check just the month key in this test as an example. Other tests check all
+    # the keys.
+    reported_metric_stats_key = application_key(
+      @service_id,
+      @application.id,
+      metric_id,
+      :month,
+      Period::Boundary.start_of(:month, current_time.getutc).to_compact_s
+    )
+    assert_equal 1, @storage.get(reported_metric_stats_key).to_i
+  end
+
   test 'report does not aggregate anything when at least one transaction is invalid' do
     post '/transactions.xml',
        :provider_key => @provider_key,

--- a/test/integration/report_test.rb
+++ b/test/integration/report_test.rb
@@ -1033,8 +1033,6 @@ class ReportTest < Test::Unit::TestCase
   end
 
   test 'report can include a response code' do
-    Time.now.utc
-
     current_time = Time.utc(2017, 1, 1)
 
     Timecop.freeze(current_time) do

--- a/test/unit/transactor_test.rb
+++ b/test/unit/transactor_test.rb
@@ -122,6 +122,52 @@ class TransactorTest < Test::Unit::TestCase
     end
   end
 
+  test 'report does not include usages of 0 when it generates a report job' do
+    current_time = Time.now
+
+    metric_name = 'some_metric'
+    Metric.save(service_id: @service_id, id: next_id, name: metric_name)
+
+    transactions = {
+      '0' => {
+        app_id: @application_one.id,
+        usage: { 'hits' => 0, metric_name => 1 },
+        timestamp: current_time
+      },
+      '1' => {
+        app_id: @application_two.id,
+        usage: { 'hits' => 0, metric_name => 2 },
+        timestamp: current_time
+      }
+    }
+
+    Timecop.freeze(current_time) do
+      Transactor.report(@provider_key, @service_id, transactions)
+    end
+
+    # "hits" should not appear because it has a usage of 0.
+    transactions.each do |_idx, tx| tx[:usage].delete('hits') end
+
+    assert_queued(
+      Transactor::ReportJob,
+      [@service_id, transactions, current_time.to_f, @context_info]
+    )
+  end
+
+  test 'report does not enqueue a job if there is not at least a transaction with usage != 0' do
+    transactions = {
+      '0' => {
+        app_id: @application_one.id,
+        usage: { 'hits' => 0 },
+        timestamp: Time.now
+      }
+    }
+
+    assert_nothing_queued do
+      Transactor.report(@provider_key, @service_id, transactions)
+    end
+  end
+
   test 'authorize returns status object with the plan name' do
     status = Transactor.authorize(@provider_key, :app_id => @application_one.id)
 


### PR DESCRIPTION
This PR makes sure that no usages of 0 are reported in the authrep and the report endpoints.

The problem was that they were reported, and report jobs ended up creating stats keys with a value of 0. A stats key set to 0 is equivalent to a non-existing one when rate-limiting, so the feature was working correctly but wasting space in the DB.