### PR TITLE
Provide helper for "first traffic" set in Stats::Keys

### DIFF
--- a/lib/3scale/backend/application_events.rb
+++ b/lib/3scale/backend/application_events.rb
@@ -40,10 +40,8 @@ module ThreeScale
       private
 
       def self.first_traffic(service_id, application_id)
-        key = Stats::Keys.applications_key_prefix(
-          Stats::Keys.service_key_prefix(service_id)
-        )
-        if storage.sadd(key, encode_key(application_id))
+        if storage.sadd(Stats::Keys.set_of_apps_with_traffic(service_id),
+                        encode_key(application_id))
           EventStorage.store(:first_traffic,
                              { service_id:     service_id,
                                application_id: application_id,

--- a/lib/3scale/backend/stats/keys.rb
+++ b/lib/3scale/backend/stats/keys.rb
@@ -70,6 +70,12 @@ module ThreeScale
           key
         end
 
+        def set_of_apps_with_traffic(service_id)
+          Stats::Keys.applications_key_prefix(
+            Stats::Keys.service_key_prefix(service_id)
+          )
+        end
+
         # We want all the buckets to go to the same Redis shard.
         # The reason is that SUNION support in Twemproxy requires that the
         # supplied keys hash to the same server.


### PR DESCRIPTION
Minor refactor. Adds a helper in the `Stats::Keys` module to get the "first traffic" set for a given service ID.