### PR TITLE
Update async-redis to 0.5.1

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -59,7 +59,7 @@ gem 'sinatra-contrib', '~> 2.0.3'
 # Optional external error logging services
 gem 'bugsnag', '~> 6', require: nil
 gem 'yabeda-prometheus', '~> 0.5.0'
-gem 'async-redis', '~> 0.5'
+gem 'async-redis', '~> 0.5.1'
 gem 'falcon', '~> 0.35'
 
 # Use a patched redis-rb that fixes an issue when trying to connect with

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
       async (~> 1.14)
     async-pool (0.2.0)
       async (~> 1.8)
-    async-redis (0.5.0)
+    async-redis (0.5.1)
       async (~> 1.8)
       async-io (~> 1.10)
       async-pool (~> 0.2)
@@ -142,7 +142,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nio4r (2.5.2)
+    nio4r (2.5.4)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     parslet (1.8.2)
@@ -241,7 +241,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
-    timers (4.3.0)
+    timers (4.3.2)
     toml (0.2.0)
       parslet (~> 1.8.0)
     tzinfo (1.2.7)
@@ -267,7 +267,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.3.1)
   apisonator!
-  async-redis (~> 0.5)
+  async-redis (~> 0.5.1)
   async-rspec
   aws-sdk (= 2.4.2)
   benchmark-ips (~> 2.7.2)

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -67,7 +67,7 @@ GEM
       async (~> 1.14)
     async-pool (0.2.0)
       async (~> 1.8)
-    async-redis (0.5.0)
+    async-redis (0.5.1)
       async (~> 1.8)
       async-io (~> 1.10)
       async-pool (~> 0.2)
@@ -131,7 +131,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nio4r (2.5.2)
+    nio4r (2.5.4)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     parslet (1.8.2)
@@ -227,7 +227,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
-    timers (4.3.0)
+    timers (4.3.2)
     toml (0.2.0)
       parslet (~> 1.8.0)
     tzinfo (1.2.7)
@@ -250,7 +250,7 @@ PLATFORMS
 
 DEPENDENCIES
   apisonator!
-  async-redis (~> 0.5)
+  async-redis (~> 0.5.1)
   async-rspec
   benchmark-ips (~> 2.7.2)
   bugsnag (~> 6)


### PR DESCRIPTION
Raises the minimum version to 0.5.1. It's not the latest release, but it's the latest that still supports ruby 2.4.
That version includes the PR that I contributed to add support for Redis Sentinels.