### PR TITLE
Async worker: stop sharing redis client instance with the job fetcher thread

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -53,6 +53,7 @@ gem 'rake', '~> 13.0'
 gem 'builder', '= 3.2.3'
 # Use a patched resque to allow reusing their Airbrake Failure class
 gem 'resque', git: 'https://github.com/3scale/resque', branch: '3scale'
+gem 'redis-namespace', '~>1.8.0'
 gem 'rack', '~> 2.1.4'
 gem 'sinatra', '~> 2.0.3'
 gem 'sinatra-contrib', '~> 2.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rake (13.0.1)
-    redis-namespace (1.6.0)
+    redis-namespace (1.8.0)
       redis (>= 3.0.4)
     resque_spec (0.17.0)
       resque (>= 1.19.0)
@@ -291,6 +291,7 @@ DEPENDENCIES
   rack-test (~> 0.8.2)
   rake (~> 13.0)
   redis!
+  redis-namespace (~> 1.8.0)
   resque!
   resque_spec (~> 0.17.0)
   resque_unit (~> 0.4.4)!

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -166,7 +166,7 @@ GEM
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rake (13.0.1)
-    redis-namespace (1.6.0)
+    redis-namespace (1.8.0)
       redis (>= 3.0.4)
     resque_spec (0.17.0)
       resque (>= 1.19.0)
@@ -272,6 +272,7 @@ DEPENDENCIES
   rack-test (~> 0.8.2)
   rake (~> 13.0)
   redis!
+  redis-namespace (~> 1.8.0)
   resque!
   resque_spec (~> 0.17.0)
   resque_unit (~> 0.4.4)!

--- a/spec/integration/job_queues_spec.rb
+++ b/spec/integration/job_queues_spec.rb
@@ -3,6 +3,8 @@ require_relative '../spec_helper'
 module ThreeScale
   module Backend
     context 'when failed jobs are rescheduled' do
+      include SpecHelpers::WorkerHelper
+
       let(:provider_key) { 'a_provider_key' }
       let(:service_id) { 'a_service_id' }
       let(:app_id) { 'an_app_id' }
@@ -46,7 +48,7 @@ module ThreeScale
 
           # Try to process the job. It will fail and will be moved to the
           # failed jobs queue.
-          Worker.work(one_off: true)
+          process_one_job
           expect(Resque.size(queue)).to be_zero
           expect(Resque::Failure.count).to eq 1
 

--- a/spec/integration/stats_partition_generator_job_spec.rb
+++ b/spec/integration/stats_partition_generator_job_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../spec_helper'
 
 RSpec.describe ThreeScale::Backend::Stats::PartitionGeneratorJob do
+  include SpecHelpers::WorkerHelper
+
   let(:service_id) { '123456' }
   let(:applications) { %w[1] }
   let(:metrics) { %w[10] }
@@ -27,8 +29,7 @@ RSpec.describe ThreeScale::Backend::Stats::PartitionGeneratorJob do
     without_resque_spec do
       job.run_async
       expect(Resque.size(stats_queue)).to eq 1
-      # Try to process the job.
-      ThreeScale::Backend::Worker.work(one_off: true)
+      process_one_job
       expect(Resque.size(stats_queue)).to eq((num_keys_generated.to_f / configuration.stats.delete_partition_batch_size).ceil)
     end
   end

--- a/spec/spec_helpers/worker_helper.rb
+++ b/spec/spec_helpers/worker_helper.rb
@@ -1,0 +1,11 @@
+module SpecHelpers
+  module WorkerHelper
+    def process_one_job
+      # The async worker creates a reactor and all the tests are run within a
+      # reactor (see the config.around(:each) call on spec_helper.rb). To avoid
+      # the worker creating a nested reactor inside the one already running, we
+      # run Worker.work in its own thread.
+      Thread.new { ThreeScale::Backend::Worker.work(one_off: true) }.join
+    end
+  end
+end

--- a/test/test_helpers/storage.rb
+++ b/test/test_helpers/storage.rb
@@ -100,6 +100,11 @@ module TestHelpers
                 inner.respond_to_missing? m
               end
 
+              # Needed to call Redis::Namespace.new(). Used in WorkerAsync.
+              def respond_to?(m)
+                inner.respond_to?(m)
+              end
+
               private
 
               attr_reader :inner

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -33,8 +33,9 @@ class WorkerTest < Test::Unit::TestCase
   end
 
   def test_no_jobs_in_the_queue
-    redis = Redis.any_instance
-    redis.expects(:blpop).returns(nil)
+    # Stub blpop to avoid waiting until timeout.
+    Redis.any_instance.stubs(:blpop).returns(nil)
+    StorageAsync::Client.any_instance.stubs(:blpop).returns(nil)
 
     Worker.work(:one_off => true)
   end


### PR DESCRIPTION
This PR fixes a bug that triggers sometimes in the worker with async enabled and when a job fails. The root cause is that the main thread and the one that fetches job from the queue were sharing the same Redis instance to access the queue DB. Reusing the same instance raises errors because a fiber is shared between different threads.

This PR also includes some related fixes in the test suite.