### PR TITLE
Async worker: exit cleanly when fetcher fails

### DIFF
--- a/lib/3scale/backend/job_fetcher.rb
+++ b/lib/3scale/backend/job_fetcher.rb
@@ -92,6 +92,9 @@ module ThreeScale
           end
         end
 
+      rescue Exception => e
+        Worker.logger.notify(e)
+      ensure
         job_queue.close
       end
 

--- a/lib/3scale/backend/worker_async.rb
+++ b/lib/3scale/backend/worker_async.rb
@@ -68,6 +68,10 @@ module ThreeScale
           # unblocks when there are new jobs or when .close() is called
           job = @jobs.pop
 
+          # If job is nil, it means that the queue is closed. No more jobs are
+          # going to be pushed, so shutdown.
+          shutdown unless job
+
           break if @shutdown
 
           @reactor.async { perform(job) }


### PR DESCRIPTION
When the job fetcher thread fails, it does not make sense to keep the worker running, because it's not going to do anything useful.
This PR notifies when the job fetcher fails and exits cleanly ensuring that the shared job queue is always closed.