### PR TITLE
Delete stats keys when using "set to 0" (`#0`)

### DIFF
--- a/docs/set_usages.md
+++ b/docs/set_usages.md
@@ -1,0 +1,14 @@
+# Set usages
+
+When reporting a usage using the authrep or the report endpoints, the value
+reported is added to the current one, but Apisonator offers a way to set values
+instead of increasing them. If the value starts with a "#", Apisonator
+interprets it as a set instead of an increase.
+
+This feature was deprecated a long time ago. It has some tricky corners cases
+documented in the test suite.
+
+When a usage is set to 0 using `#0`, Apisonator deletes the associated stats
+keys in Redis. We don't need to store stats keys set to 0. It wastes Redis
+memory because for rate-limiting and stats, a key of set to 0 is equivalent to a
+key that does not exist.

--- a/test/test_helpers/storage_keys.rb
+++ b/test/test_helpers/storage_keys.rb
@@ -26,5 +26,18 @@ module TestHelpers
       end
     end
 
+    def app_keys_for_all_periods(service_id, app_id, metric_id, time)
+      time_utc = time.getutc
+
+      ThreeScale::Backend::Period::SYMBOLS.map do |period|
+        application_key(
+          service_id,
+          app_id,
+          metric_id,
+          period,
+          ThreeScale::Backend::Period::Boundary.start_of(period, time_utc).to_compact_s
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is related to https://github.com/3scale/apisonator/pull/247

The idea is the same, avoid creating stats keys set to 0.