### PR TITLE
Gemfiles: pin rack-test to 0.8.2

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -15,11 +15,15 @@ platform :ruby do
 end
 
 group :test do
+  # Newer versions of rack-test don't work well with rspec-api-documentation.
+  # See https://github.com/rack/rack-test/pull/223 &
+  # https://github.com/zipmark/rspec_api_documentation/issues/342
+  gem 'rack-test',     '= 0.8.2'
+
   gem 'benchmark-ips', '~> 2.7.2'
   gem 'mocha',         '~> 1.3'
   gem 'nokogiri',      '~> 1.10.8'
   gem 'pkg-config',    '~> 1.1.7'
-  gem 'rack-test',     '~> 0.8.2'
   gem 'resque_unit',   '~> 0.4.4', source: 'https://rubygems.org'
   gem 'test-unit',     '~> 3.2.6'
   gem 'resque_spec',   '~> 0.17.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ DEPENDENCIES
   pry-doc (~> 0.11.1)
   puma!
   rack (~> 2.1.4)
-  rack-test (~> 0.8.2)
+  rack-test (= 0.8.2)
   rake (~> 13.0)
   redis!
   redis-namespace (~> 1.8.0)

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -269,7 +269,7 @@ DEPENDENCIES
   pry-doc (~> 0.11.1)
   puma!
   rack (~> 2.1.4)
-  rack-test (~> 0.8.2)
+  rack-test (= 0.8.2)
   rake (~> 13.0)
   redis!
   redis-namespace (~> 1.8.0)


### PR DESCRIPTION
When updating rack-test some tests fail because rack-test 0.8.3 includes a breaking change that doesn't work well with `rspec-apic-document`. See the github issues linked in the Gemfile.