### PR TITLE
Update our puma fork to 4.3.7

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -46,7 +46,7 @@ group :development, :test do
 end
 
 # Default server by platform
-gem 'puma', git: 'https://github.com/3scale/puma', ref: 'b034371406690d3e6c2a9301c4a48bd721f3efc3'
+gem 'puma', git: 'https://github.com/3scale/puma', branch: '3scale-4.3.7'
 # gems required by the runner
 gem 'gli', '~> 2.16.1', require: nil
 # Workers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/3scale/puma
-  revision: b034371406690d3e6c2a9301c4a48bd721f3efc3
-  ref: b034371406690d3e6c2a9301c4a48bd721f3efc3
+  revision: c0601d08695839b8ffd0f380e91c3b91c1e8b754
+  branch: 3scale-4.3.7
   specs:
-    puma (2.15.3)
+    puma (4.3.7)
+      nio4r (~> 2.0)
 
 GIT
   remote: https://github.com/3scale/redis-rb

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/3scale/puma
-  revision: b034371406690d3e6c2a9301c4a48bd721f3efc3
-  ref: b034371406690d3e6c2a9301c4a48bd721f3efc3
+  revision: c0601d08695839b8ffd0f380e91c3b91c1e8b754
+  branch: 3scale-4.3.7
   specs:
-    puma (2.15.3)
+    puma (4.3.7)
+      nio4r (~> 2.0)
 
 GIT
   remote: https://github.com/3scale/redis-rb


### PR DESCRIPTION
This PR updates our puma fork to 4.3.4. We already tried this version some time ago and know that it works.
It'd be nice to update directly to 5.x but it's not a high priority now. 4.3.4 unblocks other work, like being able to switch to UBI8.