### PR TITLE
Replace deprecated `URI.encode` calls

### DIFF
--- a/spec/unit/listener/extensions_spec.rb
+++ b/spec/unit/listener/extensions_spec.rb
@@ -9,27 +9,26 @@ module ThreeScale
 
         let(:simple_key) { :a_value }
         let(:simple_val) { '1' }
-        let(:simple) { URI.encode "#{simple_key}=#{simple_val}" }
+        let(:simple) { URI.encode_www_form({ simple_key => simple_val }) }
         let(:simple_result) { { simple_key => simple_val } }
 
         let(:simple2_key) { :another_value }
         let(:simple2_val) { '2' }
-        let(:simple2) { URI.encode "#{simple2_key}=#{simple2_val}" }
+        let(:simple2) { URI.encode_www_form(simple2_key => simple2_val) }
 
         let(:multiple) { "#{simple}&#{simple2}" }
         let(:multiple_result) { { simple_key => simple_val, simple2_key => simple2_val } }
 
         let(:array_key) { :array }
         let(:array_val) { ['1', '2'] }
-        let(:array) { URI.encode "#{array_key}[]=#{array_val[0]}&#{array_key}[]=#{array_val[1]}" }
+        let(:array) { "#{array_key}[]=#{array_val[0]}&#{array_key}[]=#{array_val[1]}" }
         let(:array_result) { { array_key => array_val } }
 
         let(:hash_key) { :hash }
         let(:hash_keys) { [:key1, :key2 ] }
         let(:hash_vals) { ['1', '2'] }
-        let(:hash) { URI.encode(
-                         "#{hash_key}[#{hash_keys[0]}]=#{hash_vals[0]}&" \
-                         "#{hash_key}[#{hash_keys[1]}]=#{hash_vals[1]}") }
+        let(:hash) { "#{hash_key}[#{hash_keys[0]}]=#{hash_vals[0]}&" \
+                     "#{hash_key}[#{hash_keys[1]}]=#{hash_vals[1]}" }
         let(:hash_result) {
           { hash_key => Hash[hash_keys.map(&:to_s).zip(hash_vals)] }
         }
@@ -37,7 +36,7 @@ module ThreeScale
         let(:combined) { multiple + '&' + array + '&' + hash }
         let(:combined_result) { multiple_result.merge(array_result.merge(hash_result)) }
 
-        let(:spaces) { URI.encode 'a key= a value'}
+        let(:spaces) { URI.encode_www_form('a key': ' a value') }
         let(:spaces_result) { { 'a key': ' a value' } }
 
         let(:special_characters_key) {
@@ -47,7 +46,7 @@ module ThreeScale
           :"a#{CGI.escape '&'}value#{CGI.escape '='}"
         }
         let(:special_characters) {
-          URI.encode "#{special_characters_key}=#{special_characters_value}"
+          URI.encode_www_form("#{special_characters_key}": "#{special_characters_value}")
         }
         let(:special_characters_result) {
           { "#{special_characters_key}": "#{special_characters_value}" }

--- a/test/test_helpers/extensions.rb
+++ b/test/test_helpers/extensions.rb
@@ -6,11 +6,11 @@ module TestHelpers
     end
 
     module ExtensionConstants
-      NO_BODY = URI.encode('no_body=1').freeze
-      REJECTION_REASON_HEADER = URI.encode('rejection_reason_header=1').freeze
-      HIERARCHY = URI.encode('hierarchy=1').freeze
-      LIMIT_HEADERS = URI.encode('limit_headers=1').freeze
-      FLAT_USAGE = URI.encode('flat_usage=1').freeze
+      NO_BODY = URI.encode_www_form(no_body: 1).freeze
+      REJECTION_REASON_HEADER = URI.encode_www_form(rejection_reason_header: 1).freeze
+      HIERARCHY = URI.encode_www_form(hierarchy: 1).freeze
+      LIMIT_HEADERS = URI.encode_www_form(limit_headers: 1).freeze
+      FLAT_USAGE = URI.encode_www_form(flat_usage: 1).freeze
     end
 
     module ClassMethods


### PR DESCRIPTION
Ruby 2.7 throws a warning when calling `URI.encode`:
"warning: URI.escape is obsolete" (encode is an alias of escape)