### PR TITLE
Remove redundant prometheus config param

### DIFF
--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -58,7 +58,6 @@ module ThreeScale
       config.add_section(:internal_api, :user, :password)
       config.add_section(:master, :metrics)
       config.add_section(:worker_prometheus_metrics, :enabled, :port)
-      config.add_section(:listener_prometheus_metrics, :enabled, :port)
 
       config.add_section(
           :async_worker,

--- a/lib/3scale/backend/rack.rb
+++ b/lib/3scale/backend/rack.rb
@@ -17,7 +17,10 @@ module ThreeScale
 
           Backend::Logging::External.setup_rack self
 
-          if Backend.configuration.listener_prometheus_metrics.enabled
+          # Notice that this cannot be specified via config, it needs to be an
+          # ENV because the metric server is started in Puma/Falcon
+          # "before_fork" and the configuration is not loaded at that point.
+          if ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED'].to_s.downcase.freeze == 'true'.freeze
             use Rack::Prometheus
           end
 

--- a/lib/3scale/prometheus_server.rb
+++ b/lib/3scale/prometheus_server.rb
@@ -4,7 +4,7 @@
 require_relative '../3scale/backend/listener_metrics'
 
 # Config is not loaded at this point, so read ENV instead.
-if ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED'].to_s == 'true'
+if ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED'].to_s.downcase.freeze == 'true'.freeze
   prometheus_port = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_PORT']
   ThreeScale::Backend::ListenerMetrics.start_metrics_server(prometheus_port)
 end

--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -63,8 +63,6 @@ ThreeScale::Backend.configure do |config|
   config.workers_logger_formatter = "#{ENV['CONFIG_WORKERS_LOGGER_FORMATTER']}".to_sym
   config.worker_prometheus_metrics.enabled = parse_boolean_env('CONFIG_WORKER_PROMETHEUS_METRICS_ENABLED')
   config.worker_prometheus_metrics.port = ENV['CONFIG_WORKER_PROMETHEUS_METRICS_PORT']
-  config.listener_prometheus_metrics.enabled = parse_boolean_env('CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED')
-  config.listener_prometheus_metrics.port = ENV['CONFIG_LISTENER_PROMETHEUS_METRICS_PORT']
   config.async_worker.max_concurrent_jobs = parse_int_env('CONFIG_ASYNC_WORKER_MAX_CONCURRENT_JOBS')
   config.async_worker.max_pending_jobs = parse_int_env('CONFIG_ASYNC_WORKER_MAX_PENDING_JOBS')
   config.async_worker.seconds_before_fetching_more = parse_int_env('CONFIG_ASYNC_WORKER_WAIT_SECONDS_FETCHING')


### PR DESCRIPTION
This PR removes a redundant config param used to enable Prometheus metrics in the listener.

We already have an ENV to do that and we need it because the metric server is started in Puma/Falcon "before_fork" and the configuration is not loaded at that point.