### PR TITLE
Perf optimization: Check if alerts can be raised before calculating utilization

### DIFF
--- a/lib/3scale/backend/stats/aggregator.rb
+++ b/lib/3scale/backend/stats/aggregator.rb
@@ -149,6 +149,12 @@ module ThreeScale
               # enqueued. No need to update alerts in that case.
               next unless application
 
+              # The operations below are costly. They load all the usage limits
+              # and current usages to find the current utilization levels.
+              # That's why before that, we check if there are any alerts that
+              # can be raised.
+              next unless Alerts.can_raise_more_alerts?(service_id, values[:application_id])
+
               application.load_metric_names
               usage = Usage.application_usage(application, current_timestamp)
               status = Transactor::Status.new(service_id: service_id,

--- a/test/unit/alerts_test.rb
+++ b/test/unit/alerts_test.rb
@@ -2,10 +2,12 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 require '3scale/backend/alert_limit'
 
 class AlertsTest < Test::Unit::TestCase
-  def setup
-    @service_id = 10
+  include TestHelpers::Sequences
 
-    Alerts::ALERT_BINS.each { |val| AlertLimit.save(@service_id, val) }
+  def setup
+    @storage = Storage.instance(true)
+    @service_id = next_id
+    @application_id = next_id
   end
 
   test 'check proper use of bins' do
@@ -14,5 +16,34 @@ class AlertsTest < Test::Unit::TestCase
     assert_equal Alerts.utilization_discrete(0.89), 80
     assert_equal Alerts.utilization_discrete(1.22), 120
     assert_equal Alerts.utilization_discrete(6.02), 300
+  end
+
+  test 'can_raise_more_alerts? returns false when there are no allowed bins' do
+    assert_false(Alerts.can_raise_more_alerts?(@service_id, @application_id))
+  end
+
+  test 'can_raise_more_alerts? returns false when there is already an alert for the highest bin' do
+    allowed_bins = [50, 100]
+    allowed_bins.each { |bin| AlertLimit.save(@service_id, bin) }
+
+    key_highest_already_notified = Alerts.send(
+      :key_already_notified, @service_id, @application_id, allowed_bins.sort.last
+    )
+    @storage.set(key_highest_already_notified, '1')
+
+    assert_false(Alerts.can_raise_more_alerts?(@service_id, @application_id))
+  end
+
+  test 'can_raise_more_alerts? returns true when there are no alerts for the highest bin' do
+    allowed_bins = [50, 100, 200]
+    allowed_bins.each { |bin| AlertLimit.save(@service_id, bin) }
+
+    # Set notified for a level that's not the highest
+    key_already_notified = Alerts.send(
+      :key_already_notified, @service_id, @application_id, allowed_bins.sort[-2]
+    )
+    @storage.set(key_already_notified, '1')
+
+    assert_true(Alerts.can_raise_more_alerts?(@service_id, @application_id))
   end
 end


### PR DESCRIPTION
The `update_alerts` call in `Aggregator` can be costly. It loads the usages limits and the current usages to check whether an alert should be raised. This PR introduces a perf optimization. It adds a check to see if there can still be alerts raised for an app (there can only be one every 24h per alert level) before calculating all the usages.
