### PR TITLE
Delete unused Service attrs related with end-users functionality

### DIFF
--- a/lib/3scale/backend/service.rb
+++ b/lib/3scale/backend/service.rb
@@ -4,12 +4,11 @@ module ThreeScale
       include Storable
 
       # list of attributes to be fetched from storage
-      ATTRIBUTES = %i[state referrer_filters_required backend_version
-                      default_user_plan_name provider_key].freeze
+      ATTRIBUTES = %i[state referrer_filters_required backend_version provider_key].freeze
       private_constant :ATTRIBUTES
 
       attr_reader :state
-      attr_accessor :provider_key, :id, :backend_version, :default_user_plan_name
+      attr_accessor :provider_key, :id, :backend_version
       attr_writer :referrer_filters_required, :default_service
 
       class << self
@@ -202,7 +201,6 @@ module ThreeScale
           provider_key: provider_key,
           backend_version: backend_version,
           referrer_filters_required: referrer_filters_required?,
-          default_user_plan_name: default_user_plan_name,
           default_service: default_service?
         }
       end
@@ -267,7 +265,6 @@ module ThreeScale
 
       def persist_attributes
         persist_attribute :referrer_filters_required, referrer_filters_required? ? 1 : 0
-        persist_attribute :default_user_plan_name, default_user_plan_name, true
         persist_attribute :backend_version, backend_version, true
         persist_attribute :provider_key, provider_key
         persist_attribute :state, state.to_s if state

--- a/lib/3scale/backend/service.rb
+++ b/lib/3scale/backend/service.rb
@@ -5,12 +5,11 @@ module ThreeScale
 
       # list of attributes to be fetched from storage
       ATTRIBUTES = %i[state referrer_filters_required backend_version
-                      default_user_plan_id default_user_plan_name provider_key].freeze
+                      default_user_plan_name provider_key].freeze
       private_constant :ATTRIBUTES
 
       attr_reader :state
-      attr_accessor :provider_key, :id, :backend_version,
-        :default_user_plan_id, :default_user_plan_name
+      attr_accessor :provider_key, :id, :backend_version, :default_user_plan_name
       attr_writer :referrer_filters_required, :default_service
 
       class << self
@@ -203,7 +202,6 @@ module ThreeScale
           provider_key: provider_key,
           backend_version: backend_version,
           referrer_filters_required: referrer_filters_required?,
-          default_user_plan_id: default_user_plan_id,
           default_user_plan_name: default_user_plan_name,
           default_service: default_service?
         }
@@ -269,7 +267,6 @@ module ThreeScale
 
       def persist_attributes
         persist_attribute :referrer_filters_required, referrer_filters_required? ? 1 : 0
-        persist_attribute :default_user_plan_id, default_user_plan_id, true
         persist_attribute :default_user_plan_name, default_user_plan_name, true
         persist_attribute :backend_version, backend_version, true
         persist_attribute :provider_key, provider_key

--- a/spec/acceptance/api/internal/services_api_spec.rb
+++ b/spec/acceptance/api/internal/services_api_spec.rb
@@ -90,7 +90,6 @@ resource 'Services (prefix: /services)' do
         referrer_filters_required: true,
         backend_version: 'oauth',
         default_user_plan_name: 'default user plan name',
-        default_user_plan_id: 'plan ID',
         default_service: true,
         state: state
       }
@@ -161,7 +160,6 @@ resource 'Services (prefix: /services)' do
         referrer_filters_required: true,
         backend_version: 'oauth',
         default_user_plan_name: 'default user plan name',
-        default_user_plan_id: 'plan ID',
         default_service: true,
         state: state
       }

--- a/spec/acceptance/api/internal/services_api_spec.rb
+++ b/spec/acceptance/api/internal/services_api_spec.rb
@@ -102,7 +102,7 @@ resource 'Services (prefix: /services)' do
       expect(response_json['status']).to eq 'created'
 
       svc = ThreeScale::Backend::Service.load_by_id('1002')
-      expect(svc.to_hash).to eq service.merge(user_registration_required: true)
+      expect(svc.to_hash).to eq service
     end
 
     example 'Try creating a Service without specifying the service parameter in the body' do
@@ -121,7 +121,7 @@ resource 'Services (prefix: /services)' do
       expect(svc).not_to be_nil
       expect(svc).not_to respond_to :some_param
       # The returned data should not contain *some_param* attribute
-      expect(svc.to_hash).to eq service.merge(user_registration_required: true)
+      expect(svc.to_hash).to eq service
     end
 
     context 'with an service that has no state' do
@@ -173,8 +173,7 @@ resource 'Services (prefix: /services)' do
       expect(response_json['status']).to eq 'ok'
 
       svc = ThreeScale::Backend::Service.load_by_id('1001')
-      expect(svc.to_hash).to eq service.merge(id: '1001',
-                                              user_registration_required: true)
+      expect(svc.to_hash).to eq service.merge(id: '1001')
     end
 
     example 'Update Service by ID using extra params that should be ignored' do
@@ -186,8 +185,7 @@ resource 'Services (prefix: /services)' do
       expect(svc).not_to be_nil
       expect(svc).not_to respond_to :some_param
       # The returned data should not contain *some_param* attribute
-      expect(svc.to_hash).to eq service.merge(id: '1001',
-                                              user_registration_required: true)
+      expect(svc.to_hash).to eq service.merge(id: '1001')
     end
 
     context 'Create a service that has no state' do

--- a/spec/acceptance/api/internal/services_api_spec.rb
+++ b/spec/acceptance/api/internal/services_api_spec.rb
@@ -89,7 +89,6 @@ resource 'Services (prefix: /services)' do
         provider_key: 'foo',
         referrer_filters_required: true,
         backend_version: 'oauth',
-        default_user_plan_name: 'default user plan name',
         default_service: true,
         state: state
       }
@@ -159,7 +158,6 @@ resource 'Services (prefix: /services)' do
         provider_key: 'foo',
         referrer_filters_required: true,
         backend_version: 'oauth',
-        default_user_plan_name: 'default user plan name',
         default_service: true,
         state: state
       }

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -80,32 +80,6 @@ module ThreeScale
         it 'changes filters_required field to a Boolean' do
           expect(result.referrer_filters_required?).to be true
         end
-
-        describe 'user_registration_required' do
-          it 'defaults to true when not set' do
-            service = Service.save!(provider_key: 'foo', id: '7001')
-            result = Service.load_by_id(service.id)
-
-            expect(result.user_registration_required?).to be true
-          end
-
-          it 'changes to Boolean when set to Integer' do
-            service = Service.save!(
-              provider_key: 'foo', id: '7001', user_registration_required: 1)
-            result = Service.load_by_id(service.id)
-
-            expect(result.user_registration_required?).to be true
-          end
-
-          it 'is false when set to false' do
-            service = Service.save!(provider_key: 'foo', id: '7001',
-              user_registration_required: false, default_user_plan_id: '1001',
-              default_user_plan_name: "user_plan_name")
-            result = Service.load_by_id(service.id)
-
-            expect(result.user_registration_required?).to be false
-          end
-        end
       end
 
       describe '.load_with_provider_key!' do
@@ -286,28 +260,6 @@ module ThreeScale
             Service.save! id: 7002, provider_key: 'foo'
 
             expect(Service.default_id('foo')).to eq '7001'
-          end
-        end
-
-        describe 'user_registration_required massaging' do
-          it 'sets the attibute to false when already false' do
-            Service.save!(provider_key: 'foo', id: 7001,
-              user_registration_required: false, default_user_plan_id: '1001',
-              default_user_plan_name: "user_plan_name")
-
-            expect(Service.load_by_id(7001).user_registration_required?).to be false
-          end
-
-          it 'sets the attibute to true when nil' do
-            Service.save!(provider_key: 'foo', id: 7001, user_registration_required: nil)
-
-            expect(Service.load_by_id(7001).user_registration_required?).to be true
-          end
-
-          it 'sets the attibute to true when already true' do
-            Service.save!(provider_key: 'foo', id: 7001, user_registration_required: true)
-
-            expect(Service.load_by_id(7001).user_registration_required?).to be true
           end
         end
       end


### PR DESCRIPTION
This PR deletes 3 unused attributes of `Service`. Those attributes are related with the end-users functionality that was removed some time ago, so they're no longer needed.