### PR TITLE
Use OAuth service rules when using OAuth services in authorize and authrep endpoints

### DIFF
--- a/lib/3scale/backend/validators.rb
+++ b/lib/3scale/backend/validators.rb
@@ -21,6 +21,13 @@ module ThreeScale
       OAUTH_VALIDATORS = ([Validators::OauthSetting,
                            Validators::OauthKey,
                            Validators::RedirectURI] + COMMON_VALIDATORS).freeze
+
+      # OIDC specific validators will only check app keys when app_key is given.
+      #
+      # No need to add OauthSetting, since we need to check that to tell
+      # OIDC apart from the rest when calling authrep.xml (note lack of
+      # the oauth_ prefix).
+      OIDC_VALIDATORS = ([Validators::OauthKey] + COMMON_VALIDATORS).freeze
     end
   end
 end

--- a/lib/3scale/backend/validators/oauth_setting.rb
+++ b/lib/3scale/backend/validators/oauth_setting.rb
@@ -3,7 +3,7 @@ module ThreeScale
     module Validators
       class OauthSetting < Base
         def apply
-          if service.backend_version == 'oauth'
+          if service.backend_version == 'oauth'.freeze
             succeed!
           else
             fail!(OauthNotEnabled.new)

--- a/test/integration/authrep/application_keys_test.rb
+++ b/test/integration/authrep/application_keys_test.rb
@@ -12,80 +12,115 @@ class AuthrepApplicationKeysTest < Test::Unit::TestCase
 
     Memoizer.reset!
 
-    setup_oauth_provider_fixtures
+    setup_provider_fixtures
+    setup_oauth_provider_fixtures_noclobber
 
     @application = Application.save(:service_id => @service.id,
                                     :id         => next_id,
                                     :state      => :active,
                                     :plan_id    => @plan_id,
                                     :plan_name  => @plan_name)
+    @application_oauth = Application.save(:service_id => @service_oauth.id,
+                                          :id         => next_id,
+                                          :state      => :active,
+                                          :plan_id    => @plan_id,
+                                          :plan_name  => @plan_name)
   end
 
   test_authrep 'succeeds if no application key is defined nor passed' do |e|
     get e, :provider_key => @provider_key,
-           :app_id       => @application.id
+           :service_id   => @service_oauth.id,
+           :app_id       => @application_oauth.id
 
     assert_authorized
   end
 
   test_authrep 'succeeds if one application key is defined and the same one is passed' do |e|
-    application_key = @application.create_key
+    application_key = @application_oauth.create_key
 
     get e, :provider_key => @provider_key,
-           :app_id       => @application.id,
+           :service_id   => @service_oauth.id,
+           :app_id       => @application_oauth.id,
            :app_key      => application_key
 
     assert_authorized
   end
 
   test_authrep 'succeeds if multiple application keys are defined and one of them is passed' do |e|
-    application_key_one = @application.create_key
-    _application_key_two = @application.create_key
+    application_key_one = @application_oauth.create_key
+    _application_key_two = @application_oauth.create_key
 
     get e, :provider_key => @provider_key,
-           :app_id       => @application.id,
+           :service_id   => @service_oauth.id,
+           :app_id       => @application_oauth.id,
            :app_key      => application_key_one
 
     assert_authorized
   end
 
-  test_authrep 'does not authorize if application key is defined but not passed',
+  test_authrep 'does not authorize if application key is defined but not passed for non oauth services',
                except: :oauth_authrep do |e|
     @application.create_key
 
     get e, :provider_key => @provider_key,
+           :service_id   => @service.id,
            :app_id       => @application.id
 
     assert_not_authorized 'application key is missing'
   end
 
-  test_authrep 'does not authorize if application key is defined but wrong one is passed' do |e|
-    @application.create_key('foo')
+  test_authrep 'authorizes if application key is defined but not passed if the service is oauth' do |e|
+    @application_oauth.create_key
 
     get e, :provider_key => @provider_key,
-           :app_id       => @application.id,
-           :app_key      => 'bar'
+           :service_id   => @service_oauth.id,
+           :app_id       => @application_oauth.id
 
-    assert_not_authorized 'application key "bar" is invalid'
+    assert_authorized
+  end
+
+  test_authrep 'authorizes if application key is defined and matches if the service is oauth' do |e|
+    application_key = @application_oauth.create_key
+
+    get e, :provider_key => @provider_key,
+           :service_id   => @service_oauth.id,
+           :app_id       => @application_oauth.id,
+           :app_key      => application_key
+
+    assert_authorized
+  end
+
+  test_authrep 'does not authorize if application key is defined but wrong even if the service is oauth',
+               except: :oauth_authrep do |e|
+    @application_oauth.create_key 'some_key'
+
+    get e, :provider_key => @provider_key,
+           :service_id   => @service_oauth.id,
+           :app_id       => @application_oauth.id,
+           :app_key      => 'invalid_key'
+
+    assert_not_authorized 'application key "invalid_key" is invalid'
   end
 
   test_authrep 'authorize with a random app key and a custom one' do |e|
-    key1 = @application.create_key('foo_app_key')
-    key2 = @application.create_key
+    key1 = @application_oauth.create_key 'foo_app_key'
+    key2 = @application_oauth.create_key
 
     get e, :provider_key => @provider_key,
-           :app_id       => @application.id,
+           :service_id   => @service_oauth.id,
+           :app_id       => @application_oauth.id,
            :app_key      => key1
 
     assert_authorized
 
     get e, :provider_key => @provider_key,
-           :app_id       => @application.id,
+           :service_id   => @service_oauth.id,
+           :app_id       => @application_oauth.id,
            :app_key      => key2
 
     assert_authorized
 
     assert_equal key1, 'foo_app_key'
-    assert_equal [key2, 'foo_app_key'].sort, @application.keys.sort
+    assert_equal [key2, 'foo_app_key'].sort, @application_oauth.keys.sort
   end
 end


### PR DESCRIPTION
We recently received tickets from users that were having issues getting OIDC to work with the 3scale Istio Adapter.

The reason is that Porta stores `client_secret`s as `app_key`s of applications. This is not needed (and arguably should not be done at all), but the effect is that any service configured as "oauth" calling the `authrep.xml` or `authorize.xml` endpoints must provide the client secret as the app_key parameter.

This does not make sense at all, since the premise is that the caller provides a signed OIDC token (ie. via the Authorization header with a bearer token authz type) and this is validated by the proxy / SM API client _before_ calling into Apisonator. There's no gain in providing yet another secret to Apisonator itself.

This change considers whether a service is configured to use OIDC when receiving auth*.xml calls (while leaving the oauth_auth*.xml calls alone), and changes the requirement that a valid `app_key` must be provided so that if none such key is provided the call will succeed, but if it is provided then success will depend on providing a correct one.

Additionally the pre-existing behaviour of being able to use `user_key`s with these kinds of services is kept, even if it does not make sense, to avoid any potential breakage (this is why only oauth_auth*.xml endpoints will require the `app_id` parameter).

This PR also paves the way to deprecate the oauth_auth*.xml endpoints, as after this lands there will be nothing in oauth_auth*.xml that cannot be done already via authorize and authrep.