### PR TITLE
Avoid duplicating definition of the Redis key that contains the alerts configured

### DIFF
--- a/lib/3scale/backend/alert_limit.rb
+++ b/lib/3scale/backend/alert_limit.rb
@@ -1,21 +1,15 @@
 module ThreeScale
   module Backend
     class AlertLimit
-      module KeyHelpers
-        def key(service_id)
-          "alerts/service_id:#{service_id}/allowed_set"
-        end
-      end
-
-      include KeyHelpers
-      extend KeyHelpers
+      include Alerts::KeyHelpers
+      extend Alerts::KeyHelpers
 
       include Storable
 
       attr_accessor :service_id, :value
 
       def save
-        storage.sadd(key(service_id), value.to_i) if valid?
+        storage.sadd(key_allowed_set(service_id), value.to_i) if valid?
       end
 
       def to_hash
@@ -26,7 +20,7 @@ module ThreeScale
       end
 
       def self.load_all(service_id)
-        values = storage.smembers(key(service_id))
+        values = storage.smembers(key_allowed_set(service_id))
         values.map do |value|
           new(service_id: service_id, value: value.to_i)
         end
@@ -38,7 +32,7 @@ module ThreeScale
       end
 
       def self.delete(service_id, value)
-        storage.srem(key(service_id), value.to_i) if valid_value?(value)
+        storage.srem(key_allowed_set(service_id), value.to_i) if valid_value?(value)
       end
 
       def self.valid_value?(value)


### PR DESCRIPTION
This PR gets rid of a duplication. The Redis key that contains the alerts configured was defined both in `AlertLimit` and `Alert`.