### PR TITLE
List application keys extension

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -35,6 +35,33 @@ checking to ensure data is consistent, ie. usage data with `n` incremented in
 5 necessarily means `n` parent, if existing, should be specified with a minimum
 of 5, not counting any other potential children.
 
+### list_app_keys (integer)
+
+This extension just outputs an XML `app_keys` section in authorization responses
+so that application keys registered to it will be listed there with the following
+format:
+
+> \<app_keys app="app_id" svc="service_id"\>
+>   \<key id="app_key1"/\>
+>    ...
+>   \<key id="app_keyN"/\>
+> \</app_keys>
+
+Applications that don't have associated keys will just show an empty `app_keys`
+section. Also do note that at the time of writing there is a maximum of 256
+such keys listed, and there is no guarantee that two successive calls will end
+up returning the same 256 keys for larger sets, nor the same order in any case.
+
+#### Accepted values
+
+- 0: disable the extension (default)
+- 1: enable the extension, always output the app_keys section regardless of
+     whether an application actually has any associated keys.
+
+Values over 1 are currently undefined, but in the future they might become
+significant. For example they could provide the maximum number of desired
+application keys returned.
+
 ### no_body (boolean)
 
 This instructs the software to avoid generating response bodies for certain endpoints.

--- a/lib/3scale/backend/transactor.rb
+++ b/lib/3scale/backend/transactor.rb
@@ -98,8 +98,9 @@ module ThreeScale
           # hierarchy parameter adds information in the response needed
           # to derive which limits affect directly or indirectly the
           # metrics for which authorization is requested.
-          hierarchy:       extensions[:hierarchy] == '1',
-          flat_usage:      extensions[:flat_usage] == '1'
+          hierarchy:       extensions[:hierarchy] == '1'.freeze,
+          flat_usage:      extensions[:flat_usage] == '1'.freeze,
+          list_app_keys:   extensions[:list_app_keys] == '1'.freeze
         }
 
         application.load_metric_names

--- a/test/integration/authorize/list_app_keys_test.rb
+++ b/test/integration/authorize/list_app_keys_test.rb
@@ -1,0 +1,220 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+
+class AuthorizeListAppKeysExtensionTest < Test::Unit::TestCase
+  include TestHelpers::Fixtures
+  include TestHelpers::Integration
+  include TestHelpers::Extensions
+
+  def setup
+    @storage = Storage.instance(true)
+    @storage.flushdb
+
+    Resque.reset!
+    Memoizer.reset!
+
+    setup_provider_fixtures
+    setup_oauth_provider_fixtures_noclobber
+
+    @application = Application.save(service_id: @service.id,
+                                    id: next_id,
+                                    state: :active,
+                                    plan_id: @plan_id,
+                                    plan_name: @plan_name)
+
+    @keys = 10.times.map { |i| "key_#{i}" }
+
+    @keys.each do |k|
+      @application.create_key k
+    end
+
+    @application_oauth = Application.save(service_id: @service_oauth.id,
+                                          id: next_id,
+                                          state: :active,
+                                          plan_id: @plan_id,
+                                          plan_name: @plan_name)
+
+    @application_oauth_w_key = Application.save(service_id: @service_oauth.id,
+                                                id: next_id,
+                                                state: :active,
+                                                plan_id: @plan_id,
+                                                plan_name: @plan_name)
+
+    @application_oauth_app_key = 'client_secret_which_should_never_really_be_used'
+    @application_oauth_w_key.create_key @application_oauth_app_key
+
+    @application_nokeys = Application.save(service_id: @service.id,
+                                           id: next_id,
+                                           state: :active,
+                                           plan_id: @plan_id,
+                                           plan_name: @plan_name)
+
+    @application_uk = Application.save(service_id: @service.id,
+                                       id: next_id,
+                                       state: :active,
+                                       plan_id: @plan_id,
+                                       plan_name: @plan_name)
+
+    @user_key = 'a_user_key'
+    Application.save_id_by_key(@service_id, @user_key, @application_uk.id)
+  end
+
+  test 'calling authorize without the list_app_keys extension does not output the application keys section' do
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service.id,
+          app_id: @application.id }
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    assert_nil xml_resp.at('app_keys')
+
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service_oauth.id,
+          app_id: @application_oauth.id }
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    assert_nil xml_resp.at('app_keys')
+
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service_oauth.id,
+          app_id: @application_oauth_w_key.id }
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    assert_nil xml_resp.at('app_keys')
+
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service.id,
+          user_key: @user_key }
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    assert_nil xml_resp.at('app_keys')
+  end
+
+  test 'calling authorize with the list_app_keys extension outputs the application keys section even if no app keys exist' do
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service.id,
+          app_id: @application_nokeys.id },
+        'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application_nokeys.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    assert_empty xml_resp.search("app_keys key")
+
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service_oauth.id,
+          app_id: @application_oauth.id },
+        'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application_oauth.id, app_keys['app']
+    assert_equal @service_oauth.id, app_keys['svc']
+
+    assert_empty xml_resp.search("app_keys key")
+
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service_oauth.id,
+          app_id: @application_oauth_w_key.id },
+        'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application_oauth_w_key.id, app_keys['app']
+    assert_equal @service_oauth.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |k| k['id'] }
+    assert_not_empty keys
+    assert_equal [@application_oauth_app_key], keys
+
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service.id,
+          user_key: @user_key },
+        'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application_uk.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    assert_empty xml_resp.search("app_keys key")
+  end
+
+  test 'calling authorize with the list_app_keys extension lists the application keys even if no app_key is specified' do
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service.id,
+          app_id: @application.id },
+        'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |n| n[:id] }
+
+    assert_equal @keys.sort, keys.sort
+  end
+
+  test 'calling authorize with the list_app_keys extension lists the application keys even if app_key is invalid' do
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service.id,
+          app_id: @application.id, app_key: 'invalid-key' },
+        'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |n| n[:id] }
+
+    assert_equal @keys.sort, keys.sort
+  end
+
+  test 'calling authorize with the list_app_keys extension lists the application keys when specifying a valid app_key' do
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service.id,
+          app_id: @application.id, app_key: @keys.sample },
+        'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |n| n[:id] }
+
+    assert_equal @keys.sort, keys.sort
+  end
+
+  test "calling authorize with the list_app_keys extension lists a maximum of #{Transactor::Status.const_get(:LIST_APP_KEYS_MAX)} application keys" do
+    max_keys = Transactor::Status.const_get :LIST_APP_KEYS_MAX
+
+    (@keys.size + 1).upto(max_keys + 1) do |i|
+      @application.create_key "key_#{i}"
+    end
+
+    get '/transactions/authorize.xml',
+        { provider_key: @provider_key, service_id: @service.id,
+          app_id: @application.id, app_key: @keys.sample },
+        'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |n| n[:id] }
+
+    assert_equal max_keys, keys.size
+  end
+end

--- a/test/integration/authrep/list_app_keys_test.rb
+++ b/test/integration/authrep/list_app_keys_test.rb
@@ -1,0 +1,217 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../test_helper')
+
+class AuthrepListAppKeysExtensionTest < Test::Unit::TestCase
+  include TestHelpers::Fixtures
+  include TestHelpers::Integration
+  include TestHelpers::Extensions
+  include TestHelpers::AuthRep
+
+  def setup
+    @storage = Storage.instance(true)
+    @storage.flushdb
+
+    Resque.reset!
+    Memoizer.reset!
+
+    setup_provider_fixtures
+    setup_oauth_provider_fixtures_noclobber
+
+    @application = Application.save(service_id: @service.id,
+                                    id: next_id,
+                                    state: :active,
+                                    plan_id: @plan_id,
+                                    plan_name: @plan_name)
+
+    @keys = 10.times.map { |i| "key_#{i}" }
+
+    @keys.each do |k|
+      @application.create_key k
+    end
+
+    @application_oauth = Application.save(service_id: @service_oauth.id,
+                                          id: next_id,
+                                          state: :active,
+                                          plan_id: @plan_id,
+                                          plan_name: @plan_name)
+
+    @application_oauth_w_key = Application.save(service_id: @service_oauth.id,
+                                                id: next_id,
+                                                state: :active,
+                                                plan_id: @plan_id,
+                                                plan_name: @plan_name)
+
+    @application_oauth_app_key = 'client_secret_which_should_never_really_be_used'
+    @application_oauth_w_key.create_key @application_oauth_app_key
+
+
+    @application_nokeys = Application.save(service_id: @service.id,
+                                           id: next_id,
+                                           state: :active,
+                                           plan_id: @plan_id,
+                                           plan_name: @plan_name)
+
+    @application_uk = Application.save(service_id: @service.id,
+                                       id: next_id,
+                                       state: :active,
+                                       plan_id: @plan_id,
+                                       plan_name: @plan_name)
+
+    @user_key = 'a_user_key'
+    Application.save_id_by_key(@service_id, @user_key, @application_uk.id)
+  end
+
+  test_authrep 'without the list_app_keys extension does not output the application keys section' do |e|
+    get e, { provider_key: @provider_key, service_id: @service.id,
+             app_id: @application.id }
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    assert_nil xml_resp.at('app_keys')
+
+    get e, { provider_key: @provider_key, service_id: @service_oauth.id,
+             app_id: @application_oauth.id }
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    assert_nil xml_resp.at('app_keys')
+
+    get e, { provider_key: @provider_key, service_id: @service_oauth.id,
+             app_id: @application_oauth_w_key.id }
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    assert_nil xml_resp.at('app_keys')
+
+    get e, { provider_key: @provider_key, service_id: @service.id,
+             user_key: @user_key }
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    assert_nil xml_resp.at('app_keys')
+  end
+
+  test_authrep 'with the list_app_keys extension outputs the application keys section even if no app keys exist' do |e|
+    get e, { provider_key: @provider_key, service_id: @service.id,
+             app_id: @application_nokeys.id },
+           'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application_nokeys.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    assert_empty xml_resp.search("app_keys key")
+
+    get e, { provider_key: @provider_key, service_id: @service_oauth.id,
+             app_id: @application_oauth.id },
+           'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application_oauth.id, app_keys['app']
+    assert_equal @service_oauth.id, app_keys['svc']
+
+    assert_empty xml_resp.search("app_keys key")
+
+    get e, { provider_key: @provider_key, service_id: @service_oauth.id,
+             app_id: @application_oauth_w_key.id },
+           'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application_oauth_w_key.id, app_keys['app']
+    assert_equal @service_oauth.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |k| k['id'] }
+    assert_not_empty keys
+    assert_equal [@application_oauth_app_key], keys
+
+    # user_key cannot be used with oauth_* endpoints, as they require an app_id
+    if e !~ /oauth_auth/
+      get e, { provider_key: @provider_key, service_id: @service.id,
+               user_key: @user_key },
+             'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+
+      xml_resp = Nokogiri::XML(last_response.body)
+      app_keys = xml_resp.at 'app_keys'
+      assert_not_nil app_keys
+      assert_equal @application_uk.id, app_keys['app']
+      assert_equal @service.id, app_keys['svc']
+
+      assert_empty xml_resp.search("app_keys key")
+    end
+  end
+
+  test_authrep 'with the list_app_keys extension lists the application keys even if no app_key is specified' do |e|
+    get e, { provider_key: @provider_key, service_id: @service.id,
+             app_id: @application.id },
+           'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+    Resque.run!
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |n| n[:id] }
+
+    assert_equal @keys.sort, keys.sort
+  end
+
+  test_authrep 'with the list_app_keys extension lists the application keys even if app_key is invalid' do |e|
+    get e, { provider_key: @provider_key, service_id: @service.id,
+             app_id: @application.id, app_key: 'invalid-key' },
+           'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+    Resque.run!
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |n| n[:id] }
+
+    assert_equal @keys.sort, keys.sort
+  end
+
+  test_authrep 'with the list_app_keys extension lists the application keys when specifying a valid app_key' do |e|
+    get e, { provider_key: @provider_key, service_id: @service.id,
+             app_id: @application.id, app_key: @keys.sample },
+           'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+    Resque.run!
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |n| n[:id] }
+
+    assert_equal @keys.sort, keys.sort
+  end
+
+  test_authrep "with the list_app_keys extension lists a maximum of #{Transactor::Status.const_get(:LIST_APP_KEYS_MAX)} application keys" do |e|
+    max_keys = Transactor::Status.const_get :LIST_APP_KEYS_MAX
+
+    (@keys.size + 1).upto(max_keys + 1) do |i|
+      @application.create_key "key_#{i}"
+    end
+
+    get e, { provider_key: @provider_key, service_id: @service.id,
+             app_id: @application.id, app_key: @keys.sample },
+           'HTTP_3SCALE_OPTIONS' => Extensions::LIST_APP_KEYS
+    Resque.run!
+
+    xml_resp = Nokogiri::XML(last_response.body)
+    app_keys = xml_resp.at 'app_keys'
+    assert_not_nil app_keys
+    assert_equal @application.id, app_keys['app']
+    assert_equal @service.id, app_keys['svc']
+
+    keys = xml_resp.search("app_keys key").map { |n| n[:id] }
+
+    assert_equal max_keys, keys.size
+  end
+end

--- a/test/test_helpers/extensions.rb
+++ b/test/test_helpers/extensions.rb
@@ -11,6 +11,7 @@ module TestHelpers
       HIERARCHY = URI.encode_www_form(hierarchy: 1).freeze
       LIMIT_HEADERS = URI.encode_www_form(limit_headers: 1).freeze
       FLAT_USAGE = URI.encode_www_form(flat_usage: 1).freeze
+      LIST_APP_KEYS = URI.encode_www_form(list_app_keys: 1).freeze
     end
 
     module ClassMethods

--- a/test/test_helpers/fixtures.rb
+++ b/test/test_helpers/fixtures.rb
@@ -92,6 +92,13 @@ module TestHelpers
       @service = Service.save!(provider_key: @provider_key, id: @service_id, backend_version: 'oauth')
     end
 
+    # alternative fixture which won't overwrite @service
+    def setup_oauth_provider_fixtures_noclobber
+      setup_provider_fixtures
+      @service_oauth_id = next_id
+      @service_oauth = Service.save!(provider_key: @provider_key, id: @service_oauth_id, backend_version: 'oauth')
+    end
+
     def setup_oauth_provider_fixtures_multiple_services
       setup_provider_fixtures_multiple_services
       @service_1 = Service.save!(:provider_key => @provider_key, :id => @service_1.id, backend_version: 'oauth')

--- a/test/test_helpers/sequences.rb
+++ b/test/test_helpers/sequences.rb
@@ -5,7 +5,7 @@ module TestHelpers
     # Generates unique id each time it's called.
     def next_id
       @@last_id += 1
-      @@last_id.to_s
+      @@last_id.to_s.encode(Encoding::UTF_8)
     end
   end
 end


### PR DESCRIPTION
This implements the `list_app_keys` extension, which outputs the `app_keys` XML section:

```xml
<app_keys app="app_id" svc="service_id">
  <key id="key_1"/>
  <key id="key_2"/>
  <key id="key_3"/>
</app_keys>
```

The fact that the `app_id` and `service_id` are also output helps with another request from the caching side to help the implementation a bit by not forcing a client to remember about the app_id/service_id the response refers to (ie. in async apps this means two less strings need to be saved across IO contexts).

/cc @rahulanand16nov @NomadXD

Closes #282.