### PR TITLE
Fix bug that causes Apisonator to stop pinging System to fetch events

### DIFF
--- a/spec/unit/event_storage_spec.rb
+++ b/spec/unit/event_storage_spec.rb
@@ -1,3 +1,4 @@
+require 'pry'
 module ThreeScale
   module Backend
     describe EventStorage do
@@ -189,8 +190,10 @@ module ThreeScale
           context 'when a ping was executed previously' do
             context 'and ping TTL is expired' do
               before do
-                stub_const("ThreeScale::Backend::EventStorage::PING_TTL", 0)
                 EventStorage.ping_if_not_empty
+
+                # Simulate expired TTL
+                EventStorage.send(:storage).del(EventStorage.send(:events_ping_key))
               end
 
               it { expect(subject).to be true }


### PR DESCRIPTION
The current code fails if the incr call is made effective in Redis but the client returns an error because of a timeout. When that happens, which should be pretty rare, apisonator stops sending events because from that moment, `ping_key_value.to_i == 1` in https://github.com/3scale/apisonator/blob/677dfbf16346bf1efebdf4fec5b5e0a9d72e8ce1/lib/3scale/backend/event_storage.rb#L99 will always be false.