### PR TITLE
Revert #295

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
     docker:
       # specify the version you desire here
-       - image: quay.io/3scale/apisonator-ci:v3.4.3
+       - image: quay.io/3scale/apisonator-ci:v3.3.1.1
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,4 +311,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH
-   2.2.21
+   1.16.6

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -289,4 +289,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH
-   2.2.21
+   1.16.6


### PR DESCRIPTION
Reverts #295 
The reason is that the version of bundler is not installed in some of our images. We need to update them before updating bundler.