### PR TITLE
Async storage: read all responses in pipelines even if some of them are errors

### DIFF
--- a/lib/3scale/backend/storage_async/async_redis.rb
+++ b/lib/3scale/backend/storage_async/async_redis.rb
@@ -13,7 +13,25 @@ module Async
 
           connection.flush
 
-          commands.size.times.map { connection.read_response }
+          # Redis returns an answer for each of the commands sent in the
+          # pipeline. But in order to keep compatibility with redis-rb, here, if
+          # there is an error in any of the commands of the pipeline we will
+          # raise an error (the first one that occurred).
+
+          first_err = nil
+
+          res = commands.size.times.map do
+            begin
+              connection.read_response
+            rescue ::Protocol::Redis::ServerError => e
+              first_err ||= e
+              nil
+            end
+          end
+
+          raise first_err if first_err
+
+          res
         end
       end
     end


### PR DESCRIPTION
Redis returns an answer for each of the commands sent in the pipeline, but we were not reading all of them. We stopped at the first error. This PR fixes the issue.