### PR TITLE
bors.toml: remove codeclimate from pr_status

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
 status = ["ci/circleci: build"]
-pr_status = ["ci/circleci: build", "workflow", "codeclimate"]
+pr_status = ["ci/circleci: build", "workflow"]
 delete_merged_branches = true


### PR DESCRIPTION
It is problematic when reverting PR's that improve the CC rating.