### PR TITLE
Gemfile.base, Gemfile{.on_prem}.lock: update puma to 4.3.9

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -46,7 +46,7 @@ group :development, :test do
 end
 
 # Default server by platform
-gem 'puma', git: 'https://github.com/3scale/puma', branch: '3scale-4.3.7'
+gem 'puma', git: 'https://github.com/3scale/puma', branch: '3scale-4.3.9'
 # gems required by the runner
 gem 'gli', '~> 2.16.1', require: nil
 # Workers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/3scale/puma
-  revision: c0601d08695839b8ffd0f380e91c3b91c1e8b754
-  branch: 3scale-4.3.7
+  revision: e7d3c53583db8d3e33a74f23f4afb59f3f29a330
+  branch: 3scale-4.3.9
   specs:
-    puma (4.3.7)
+    puma (4.3.9)
       nio4r (~> 2.0)
 
 GIT

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/3scale/puma
-  revision: c0601d08695839b8ffd0f380e91c3b91c1e8b754
-  branch: 3scale-4.3.7
+  revision: e7d3c53583db8d3e33a74f23f4afb59f3f29a330
+  branch: 3scale-4.3.9
   specs:
-    puma (4.3.7)
+    puma (4.3.9)
       nio4r (~> 2.0)
 
 GIT


### PR DESCRIPTION
Upgrade Puma to 4.3.9

CVE-2021-29509 system: rubygem-puma: incomplete fix for CVE-2019-16770 allows Denial of Service (DoS) 

https://issues.redhat.com/browse/THREESCALE-7887

Required to update 3scale puma's fork in the [3scale-4.3.9 branch](https://github.com/3scale/puma/tree/3scale-4.3.9)


