### PR TITLE
THREESCALE-7864 async-pool v0.3.12

### DIFF
--- a/Gemfile.base
+++ b/Gemfile.base
@@ -65,6 +65,7 @@ gem 'sinatra-contrib', '~> 2.0.3'
 gem 'bugsnag', '~> 6', require: nil
 gem 'yabeda-prometheus', '~> 0.5.0'
 gem 'async-redis', '~> 0.5.1'
+gem 'async-pool', '~> 0.3.12'
 gem 'falcon', '~> 0.35'
 
 # Use a patched redis-rb that fixes an issue when trying to connect with

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     airbrake (4.3.1)
       builder
       multi_json
-    async (1.24.2)
+    async (1.26.2)
       console (~> 1.0)
       nio4r (~> 2.3)
       timers (~> 4.1)
@@ -69,8 +69,8 @@ GEM
       protocol-http (~> 0.14)
     async-io (1.27.7)
       async (~> 1.14)
-    async-pool (0.2.0)
-      async (~> 1.8)
+    async-pool (0.3.12)
+      async (>= 1.25)
     async-redis (0.5.1)
       async (~> 1.8)
       async-io (~> 1.10)
@@ -272,6 +272,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 4.3.1)
   apisonator!
+  async-pool (~> 0.3.12)
   async-redis (~> 0.5.1)
   async-rspec
   aws-sdk (= 2.4.2)

--- a/Gemfile.on_prem.lock
+++ b/Gemfile.on_prem.lock
@@ -46,7 +46,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    async (1.24.2)
+    async (1.26.2)
       console (~> 1.0)
       nio4r (~> 2.3)
       timers (~> 4.1)
@@ -66,8 +66,8 @@ GEM
       protocol-http (~> 0.14)
     async-io (1.27.7)
       async (~> 1.14)
-    async-pool (0.2.0)
-      async (~> 1.8)
+    async-pool (0.3.12)
+      async (>= 1.25)
     async-redis (0.5.1)
       async (~> 1.8)
       async-io (~> 1.10)
@@ -253,6 +253,7 @@ PLATFORMS
 
 DEPENDENCIES
   apisonator!
+  async-pool (~> 0.3.12)
   async-redis (~> 0.5.1)
   async-rspec
   benchmark-ips (~> 2.7.2)


### PR DESCRIPTION
### what
 Upgrade async deps
*  async 1.24.2 -> 1.26.2
* async-pool 0.2.0 -> 0.3.12

Fixes https://issues.redhat.com/browse/THREESCALE-7864
Fixes https://github.com/3scale/apisonator/issues/308

Performed tests:

| image | async-pool version | Mem leak fixed | [connection dropping issue](https://issues.redhat.com/browse/THREESCALE-7864?focusedCommentId=19394087&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-19394087) fixed | 
| --- | --- | --- | --- |
| [latest 2.12](registry.redhat.io/3scale-amp2/backend-rhel8@sha256:437ad353f164871d741dd662015aec221406564c4de68f27c56d3e67c0cf177c) | *0.2.0* |  :x: | :heavy_check_mark: |
| [master-c1889f94-async-pool-0.3.9](quay.io/3scale/apisonator:master-c1889f94-async-pool-0.3.9) | *0.3.9* | :heavy_check_mark: | :x: |
| [master-c1889f94-async-pool-0.3.12](quay.io/3scale/apisonator:master-c1889f94-async-pool-0.3.12) | *0.3.12* |  :heavy_check_mark: | :heavy_check_mark: |

### How check mem leak

* Deploy 3scale with the operator
* Remove redis virtual databases. Change backend-redis secret, and both storage and queue have the same value: "redis://backend-redis:6379"
```
oc rollout latest deploymentconfig/backend-listener
```
* Apply backend worker async
```
oc set env deploymentconfig/backend-worker CONFIG_REDIS_ASYNC=1
```
* 3scale provisioning using buddhi
```
bundle exec perftest-toolkit-buddhi --portal https://TOKEN@3scale-admin.example.com --profile backend --public-base-url "" --private-base-url "http://toystore.my-namespace.svc:80" -o /dev/stdout
```
* Traffic generator (siege)
```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: siege
spec:
  replicas: 1
  selector:
    matchLabels:
      app: siege
  template:
    metadata:
      labels:
        app: siege
    spec:
      containers:
        - args:
            - --time=10H
            - --concurrent=16
            - --quiet
            - "http://backend-listener.my-namespace.svc/transactions/authrep.xml?service_token=2bf6c08b2f58bf513367edca811e24df52f7f5966b736186c1cc2fabeb6484ec&service_id=2555417932766&usage%5Bhits%5D=1&user_key=37002980fcb6bb2bbc9030ed5318f3d1&log%5Bcode%5D=200"
          image: ecliptik/docker-siege
          imagePullPolicy: IfNotPresent
          name: siege
      restartPolicy: Always
```
* Monitor backend worker job queue length: make sure to keep the queue length at low levels (less than 10k, ideally less that 1k) 
```
watch -n 10  "oc rsh $(kubectl get pods -l 'deploymentConfig=backend-redis' -o json | jq '.items[0].metadata.name' -r) /bin/sh -i -c 'redis-cli llen resque:queue:priority &&redis-cli llen resque:queue:main'"
```
* prometheus query to monitor mem used by the worker
```
container_memory_working_set_bytes{cluster="", namespace="my-namespace", pod=~"backend-worker-.*", container="backend-worker", image!=""}
```
* customize backend worker image using the apimanager CR
```yaml
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  [...]
  backend:
    cronSpec:
      replicas: 1
    image: quay.io/3scale/apisonator:master-c1889f94-async-pool-0.3.12
    listenerSpec:
      replicas: 1
    workerSpec:
      replicas: 1
```

### Mem leak tests results

![mem](https://user-images.githubusercontent.com/881529/196396634-b47d9c0d-ddbd-4512-be57-8a964108361e.png)

As it can bee seen, 2.12 image shows the memory increasing while other images show stable memory usage


### How check connection management issue

To verify connection issue, explained [here](https://issues.redhat.com/browse/THREESCALE-7864?focusedCommentId=19394087&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-19394087) and [here](https://github.com/socketry/async-pool/issues/10), a [socat](https://www.redhat.com/sysadmin/getting-started-socat) relay server was used as proxy to monitor connection management. 

* Deploy 3scale as explained above with async mode enabled in backend.
* Downscale to 0 replicas the worker deployed in the cluster using the apimanager CR
```yaml
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  [...]
  backend:
    cronSpec:
      replicas: 1
    image: quay.io/3scale/apisonator:master-c1889f94-async-pool-0.3.12
    listenerSpec:
      replicas: 1
    workerSpec:
      replicas: 0
```
* Port forward locally to the backend redis service
```
kubectl port-forward service/backend-redis 6379
```
* Run socat monitoring connections (`-d -d` ) and proxying in port 7379
```
socat -d -d TCP-LISTEN:7379,fork TCP:127.0.0.1:6379
```
* Run backend worker locally
  * it needs a little patch
```diff
--- a/bin/3scale_backend_worker
+++ b/bin/3scale_backend_worker
@@ -10,7 +10,7 @@ end
 options = {
   multiple: true,
   dir_mode: :normal,
-  dir: '/var/run/3scale'
+  dir: '/home/eguzki/tmp/3scale-backend-worker'
 }
```
```
$ cd apisonator
$ CONFIG_FILE=./openshift/3scale_backend.conf CONFIG_REDIS_ASYNC=1 CONFIG_WORKERS_LOG_FILE=/dev/stdout CONFIG_REDIS_PROXY="redis://127.0.0.1:7379" CONFIG_QUEUES_MASTER_NAME="redis://127.0.0.1:7379" RACK_ENV=production bundle exec 3scale_backend_worker run
```

* The number of connections should be stable. There should not be logs about creating and dropping connections continuously. If the dropping connection issue happens, socat shows the client dropping connection *continuously*, connections are not reused. Example of a socat log showing dropped connection:
```
2021/12/02 12:54:34 socat[861] N socket 1 (fd 6) is at EOF
```



