### PR TITLE
fix ci image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/3scale/apisonator-ci
-MAINTAINER Alejandro Martinez Ruiz <amr@redhat.com>
+MAINTAINER Eguzki Astiz Lezaun <eastizle@redhat.com>
 
 ARG APP_HOME
 RUN mkdir "${APP_HOME}"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
-FROM quay.io/centos/centos:stream9
-MAINTAINER Alejandro Martinez Ruiz <amr@redhat.com>
+FROM registry.access.redhat.com/ubi9:9.1.0
+MAINTAINER Eguzki Astiz Lezaun <eastizle@redhat.com>
 
 ARG CIRCLECI_TOOLS="git openssh-clients tar gzip ca-certificates glibc-locale-source glibc-langpack-en"
 # set localtime to UTC and install basic build tools
@@ -17,42 +17,6 @@ RUN useradd -m -d "/home/${USER_NAME}" -l -G wheel ${USER_NAME} \
     && chmod 0440 "/etc/sudoers.d/${USER_NAME}"
 
 USER "${USER_NAME}"
-
-# PostgreSQL installation
-ARG POSTGRES_BUILD_DEPS="bison flex zlib-devel readline-devel openssl-devel"
-RUN test "x${POSTGRES_BUILD_DEPS}" = "x" \
-    || sudo dnf install -y ${POSTGRES_BUILD_DEPS}
-
-ARG POSTGRES_VERSION=REL_10_17
-RUN curl -sSLf "https://github.com/postgres/postgres/archive/${POSTGRES_VERSION}.tar.gz" \
-    | tar -C "/home/${USER_NAME}" -xz
-
-ARG POSTGRES_PREFIX=/usr/local
-ARG POSTGRES_DATA_PREFIX=${POSTGRES_PREFIX}/pgsql
-ARG POSTGRES_CONFIGURE_OPTIONS
-ARG POSTGRES_MAKE_OPTIONS
-RUN cd ~/postgres-"${POSTGRES_VERSION}" \
-    && ./configure --prefix="${POSTGRES_PREFIX}" --includedir=/usr/local/include \
-       --with-openssl ${POSTGRES_CONFIGURE_OPTIONS} \
-    && make ${POSTGRES_MAKE_OPTIONS}
-RUN cd ~/postgres-"${POSTGRES_VERSION}" \
-    && sudo make install \
-    && rm -rf ~/postgres-"${POSTGRES_VERSION}" \
-    # the test tooling expects the pg_ctl binary in this directory
-    && sudo mkdir -p /usr/lib/postgresql/9.5/bin \
-    && sudo ln -sf "${POSTGRES_PREFIX}/bin/pg_ctl" /usr/lib/postgresql/9.5/bin/pg_ctl \
-    && sudo useradd postgres \
-    && sudo mkdir -p "${POSTGRES_DATA_PREFIX}/data" \
-    && sudo chown -R postgres: "${POSTGRES_DATA_PREFIX}" \
-    && sudo chmod -R go-rwx "${POSTGRES_DATA_PREFIX}"
-
-RUN sudo runuser -l postgres -c \
-    "${POSTGRES_PREFIX}/bin/initdb --pgdata='${POSTGRES_DATA_PREFIX}/data' --auth='trust'" < /dev/null \
-    && sudo runuser -l postgres -c \
-    "${POSTGRES_PREFIX}/bin/postgres -D '${POSTGRES_DATA_PREFIX}/data'" \
-      > /tmp/postgres.log 2>&1 & sleep 5 \
-    && sudo runuser -l postgres -c "${POSTGRES_PREFIX}/bin/createdb test" \
-    && sudo runuser -l postgres -c "${POSTGRES_PREFIX}/bin/psql test"
 
 # Twemproxy installation
 ARG TWEMPROXY_VERSION=0.5.0
@@ -121,7 +85,7 @@ RUN echo -n "export PATH=${RBENV_BINPATH}" >> ~/.bash_rbenv \
 
 ENV PATH="${RBENV_PATH}:/home/${USER_NAME}/.local/bin:${PATH}"
 
-ARG MRI_DEPS="bzip2 zlib-devel readline-devel openssl-devel libffi-devel ncurses-devel libdb-devel perl procps-ng"
+ARG MRI_DEPS="bzip2 zlib-devel openssl-devel libffi-devel ncurses-devel libdb-devel perl procps-ng"
 RUN test "x${MRI_DEPS}" = "x" || sudo dnf install -y ${MRI_DEPS}
 
 ARG OPENSSL_SRC_PATH=/home/${USER_NAME}/openssl_1_1_1

--- a/script/lib/functions
+++ b/script/lib/functions
@@ -1,7 +1,6 @@
 REDIS_PORTS=(7379 7380 6379)
 REDIS_UNIX_SOCKET_PREFIX="/tmp/redis_unix"
 TWEMPROXY_PIDFILE="/tmp/twemproxy_backend_tests.pid"
-POSTGRES_PIDFILE="/tmp/postgres_backend_tests.pid"
 
 # helper for daemonizing processes from the shell
 function daemonize {
@@ -59,23 +58,14 @@ function stop_twemproxy {
     kill_pidfile ${TWEMPROXY_PIDFILE}
 }
 
-function start_postgresql {
-    daemonize sudo -u postgres sh -c '/usr/lib/postgresql/9.5/bin/pg_ctl -D /usr/local/pgsql/data start' > /dev/null
-}
-
-function stop_postgresql {
-    sudo kill -TERM `sudo head -1 /usr/local/pgsql/data/postmaster.pid`
-}
-
 function start_services {
-    start_postgresql
     start_redis
     start_twemproxy
 }
 
 function stop_services {
     local pids
-    for fn in stop_redis stop_twemproxy stop_postgresql; do
+    for fn in stop_redis stop_twemproxy; do
 	eval "${fn}" &
 	pids[${fn}]=$!
     done


### PR DESCRIPTION
### what 

CI image was based on `quay.io/centos/centos:stream9` which reached EOL and cannot be used. When trying to build dev image from the CI image, the installation of the packages failed.

This PR depends on #325 because that PR updates the Gemfile, simplifying it. The new Gemfile removes some dependencies, one of them being `pg` which was used to access PostgreSQL. Since `pg` is no longer needed, postgreSQL is not needed in the CI image either. Thus, this PR removes postgreSQL from the CI image. 

The new image is based on UBI 9 `registry.access.redhat.com/ubi9:9.1.0`. 

Dev notes: there were some issues installing postgreSQL dependencies such as `bison`, `flex` and `readline-devel`. Since postgreSQL is no longer needed, the issues were gone.

Once merged, the new CI image must be pushed to `quay.io/3scale/apisonator-ci` to be used in the dev image.

### Verification steps

* build new CI image

```
make ci-build
```

* run dev env

```
make dev
```

* additionally, you can run tests from the container

```
script/ci
```
