### PR TITLE
THREESCALE-10649: Enable dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ spec/reports/*
 bench.txt
 3scale_backend.state
 3scale_backend.sock
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development do
   gem 'pry',      '~> 0.14'
   gem 'pry-doc',  '~> 1.1'
   gem 'license_finder', '~> 7.0'
+  gem 'dotenv', '~> 2.8.1'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     daemons (1.2.4)
     diff-lcs (1.3)
     docile (1.1.5)
+    dotenv (2.8.1)
     dry-initializer (3.0.3)
     falcon (0.42.3)
       async
@@ -266,6 +267,7 @@ DEPENDENCIES
   builder (= 3.2.3)
   codeclimate-test-reporter (~> 0.6.0)
   daemons (= 1.2.4)
+  dotenv (~> 2.8.1)
   falcon (~> 0.35)
   gli (~> 2.16.1)
   hiredis (~> 0.6.1)

--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -2,6 +2,7 @@ require '3scale/backend/configuration/loader'
 require '3scale/backend/environment'
 require '3scale/backend/configurable'
 require '3scale/backend/errors'
+require 'dotenv'
 
 module ThreeScale
   module Backend
@@ -67,6 +68,8 @@ module ThreeScale
       config.legacy_referrer_filters = false
 
       # Load configuration from a file.
+      Dotenv.load if development?
+
       config.load!([
         '/etc/3scale_backend.conf',
         '~/.3scale_backend.conf',


### PR DESCRIPTION
**JIRA issue**
[THREESCALE-10649](https://issues.redhat.com/browse/THREESCALE-10649)

**What this PR does**
`dotenv` gem has been added to facilitate the use of environment variables at development.

**Verification steps**
Try to run apisonator worker adding the following env variables at your `.env` file: 
```
CONFIG_INTERNAL_API_USER=MY_CONFIG_INTERNAL_API_USER
CONFIG_INTERNAL_API_PASSWORD=MY_CONFIG_INTERNAL_API_PASSWORD
CONFIG_QUEUES_MASTER_NAME=MY_CONFIG_QUEUES_MASTER_NAME
CONFIG_REDIS_PROXY=MY_CONFIG_REDIS_PROXY
```

Confirm that the worker runs.

