### PR TITLE
Don't require dotenv in production

### DIFF
--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -2,7 +2,7 @@ require '3scale/backend/configuration/loader'
 require '3scale/backend/environment'
 require '3scale/backend/configurable'
 require '3scale/backend/errors'
-require 'dotenv'
+require 'dotenv/load' if ENV['RACK_ENV'] == 'development'
 
 module ThreeScale
   module Backend
@@ -66,9 +66,6 @@ module ThreeScale
       config.master.metrics = Struct.new(*master_metrics).new
 
       config.legacy_referrer_filters = false
-
-      # Load configuration from a file.
-      Dotenv.load if development?
 
       config.load!([
         '/etc/3scale_backend.conf',


### PR DESCRIPTION
https://github.com/3scale/apisonator/pull/358 broke the operator. It tries to `require 'dotenv'` but it's not installed on production bundles.

This PR requires `dotenv` only for development