### PR TITLE
THREESCALE-10605: Add support for sentinels in Async mode

### DIFF
--- a/lib/3scale/backend/storage_async/client.rb
+++ b/lib/3scale/backend/storage_async/client.rb
@@ -209,8 +209,9 @@ module ThreeScale
         def init_sentinels_client(opts)
           uri = URI(opts[:url] || '')
           name = uri.host
+          role = opts[:role] || :master
 
-          Async::Redis::SentinelsClient.new(name, opts[:sentinels])
+          Async::Redis::SentinelsClient.new(name, opts[:sentinels], role)
         end
       end
     end

--- a/lib/3scale/backend/storage_async/client.rb
+++ b/lib/3scale/backend/storage_async/client.rb
@@ -1,5 +1,6 @@
 require 'async/io'
 require 'async/redis/client'
+require 'async/redis/sentinels'
 
 module ThreeScale
   module Backend
@@ -13,15 +14,6 @@ module ThreeScale
       # the Storage instance behaves likes the redis-rb client.
       class Client
         include Configurable
-
-        DEFAULT_HOST = 'localhost'.freeze
-        private_constant :DEFAULT_HOST
-
-        DEFAULT_PORT = 22121
-        private_constant :DEFAULT_PORT
-
-        HOST_PORT_REGEX = /redis:\/\/(.*):(\d+)/
-        private_constant :HOST_PORT_REGEX
 
         class << self
           attr_writer :instance
@@ -41,14 +33,7 @@ module ThreeScale
         end
 
         def initialize(opts)
-          host, port = opts[:url].match(HOST_PORT_REGEX).captures if opts[:url]
-          host ||= DEFAULT_HOST
-          port ||= DEFAULT_PORT
-
-          endpoint = Async::IO::Endpoint.tcp(host, port)
-          @redis_async = Async::Redis::Client.new(
-            endpoint, limit: opts[:max_connections]
-          )
+          @redis_async = initialize_client(opts)
           @building_pipeline = false
         end
 
@@ -200,8 +185,34 @@ module ThreeScale
         def close
           @redis_async.close
         end
-      end
 
+        private
+
+        DEFAULT_HOST = 'localhost'.freeze
+        DEFAULT_PORT = 22121
+
+        def initialize_client(opts)
+          return init_host_client(opts) unless opts.key? :sentinels
+
+          init_sentinels_client(opts)
+        end
+
+        def init_host_client(opts)
+          uri = URI(opts[:url] || '')
+          host = uri.host || DEFAULT_HOST
+          port = uri.port || DEFAULT_PORT
+
+          endpoint = Async::IO::Endpoint.tcp(host, port)
+          Async::Redis::Client.new(endpoint, limit: opts[:max_connections])
+        end
+
+        def init_sentinels_client(opts)
+          uri = URI(opts[:url] || '')
+          name = uri.host
+
+          Async::Redis::SentinelsClient.new(name, opts[:sentinels])
+        end
+      end
     end
   end
 end

--- a/test/unit/storage_async_test.rb
+++ b/test/unit/storage_async_test.rb
@@ -1,0 +1,228 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+class StorageAsyncTest < Test::Unit::TestCase
+  def test_basic_operations
+    storage = StorageAsync::Client.instance(true)
+    storage.del('foo')
+    assert_nil storage.get('foo')
+    storage.set('foo', 'bar')
+    assert_equal 'bar', storage.get('foo')
+  end
+
+  def test_redis_host_and_port
+    storage = StorageAsync::Client.send :new, url('127.0.0.1:6379')
+    assert_connection(storage)
+  end
+
+  def test_redis_url
+    storage = StorageAsync::Client.send :new, url('redis://127.0.0.1:6379/0')
+    assert_connection(storage)
+  end
+
+  def test_redis_unix
+    storage = StorageAsync::Client.send :new, url('unix:///tmp/redis_unix.6379.sock')
+    assert_connection(storage)
+  end
+
+  def test_redis_protected_url
+    assert_nothing_raised do
+      StorageAsync::Client.send :new, url('redis://user:passwd@127.0.0.1:6379/0')
+    end
+  end
+
+  def test_redis_malformed_url
+    assert_raise Storage::InvalidURI do
+      StorageAsync::Client.send :new, url('a_malformed_url:1:10')
+    end
+  end
+
+  def test_sentinels_connection_string
+    config_obj = {
+      url: 'redis://master-group-name',
+      sentinels: ',redis://127.0.0.1:26379, ,    , 127.0.0.1:36379,'
+    }
+
+    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_client(conn)
+    assert_sentinel_config(conn, url: config_obj[:url],
+                         sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                                     { host: '127.0.0.1', port: 36_379 }])
+  end
+
+  def test_sentinels_connection_array_strings
+    config_obj = {
+      url: 'redis://master-group-name',
+      sentinels: ['redis://127.0.0.1:26379 ', ' 127.0.0.1:36379', nil]
+    }
+
+    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_client(conn)
+    assert_sentinel_config(conn, url: config_obj[:url],
+                         sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                                     { host: '127.0.0.1', port: 36_379 }])
+  end
+
+  def test_sentinels_connection_array_hashes
+    config_obj = {
+      url: 'redis://master-group-name',
+      sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                  {},
+                  { host: '127.0.0.1', port: 36_379 },
+                  nil]
+    }
+
+    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_client(conn)
+    assert_sentinel_config(conn, url: config_obj[:url],
+                         sentinels: config_obj[:sentinels].compact.reject(&:empty?))
+  end
+
+  def test_sentinels_malformed_url
+    config_obj = {
+      url: 'redis://master-group-name',
+      sentinels: 'redis://127.0.0.1:26379,a_malformed_url:1:10'
+    }
+    assert_raise Storage::InvalidURI do
+      StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    end
+  end
+
+  def test_sentinels_simple_url
+    config_obj = {
+      url: 'master-group-name', # url of the sentinel master name conf
+      sentinels: 'redis://127.0.0.1:26379'
+    }
+
+    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_client(conn)
+    assert_sentinel_config(conn, url: "redis://#{config_obj[:url]}",
+                         sentinels: [{ host: '127.0.0.1', port: 26_379 }])
+  end
+
+  def test_sentinels_array_hashes_default_port
+    default_sentinel_port = Storage::Helpers.singleton_class.const_get(:DEFAULT_SENTINEL_PORT)
+    config_obj = {
+      url: 'redis://master-group-name',
+      sentinels: [{ host: '127.0.0.1' }, { host: '192.168.1.1' },
+                  { host: '192.168.1.2', port: nil },
+                  { host: '127.0.0.1', port: 36379 }]
+    }
+
+    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_client(conn)
+    assert_sentinel_config(conn, url: config_obj[:url],
+                         sentinels: [{ host: '127.0.0.1', port: default_sentinel_port },
+                                     { host: '192.168.1.1', port: default_sentinel_port },
+                                     { host: '192.168.1.2', port: default_sentinel_port },
+                                     { host: '127.0.0.1', port: 36379 }])
+  end
+
+  def test_sentinels_array_strings_default_port
+    default_sentinel_port = Storage::Helpers.singleton_class.const_get(:DEFAULT_SENTINEL_PORT)
+    config_obj = {
+      url: 'redis://master-group-name',
+      sentinels: ['127.0.0.2', 'redis://127.0.0.1',
+                  '192.168.1.1', '127.0.0.1:36379',
+                  'redis://127.0.0.1:46379']
+    }
+
+    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_client(conn)
+    assert_sentinel_config(conn, url: config_obj[:url],
+                         sentinels: [{ host: '127.0.0.2', port: default_sentinel_port },
+                                     { host: '127.0.0.1', port: default_sentinel_port },
+                                     { host: '192.168.1.1', port: default_sentinel_port },
+                                     { host: '127.0.0.1', port: 36379 },
+                                     { host: '127.0.0.1', port: 46379 }])
+  end
+
+  def test_sentinels_correct_role
+    %i[master slave].each do |role|
+      config_obj = {
+        url: 'redis://master-group-name',
+        sentinels: 'redis://127.0.0.1:26379',
+        role: role
+      }
+
+      conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+      assert_sentinel_client(conn)
+      assert_sentinel_config(conn, url: config_obj[:url],
+                           sentinels: [{ host: '127.0.0.1', port: 26_379 }],
+                           role: role)
+    end
+  end
+
+  def test_sentinels_role_empty
+    [''.to_sym, '', nil].each do |role|
+      config_obj = {
+        url: 'redis://master-group-name',
+        sentinels: 'redis://127.0.0.1:26379',
+        role: role
+      }
+      redis_cfg = Storage::Helpers.config_with(config_obj)
+      refute redis_cfg.key?(:role)
+    end
+  end
+
+  def test_role_empty_when_sentinels_does_not_exist
+    config_obj = {
+      url: 'redis://127.0.0.1:6379/0',
+      role: :master
+    }
+    redis_cfg = Storage::Helpers.config_with(config_obj)
+    refute redis_cfg.key?(:role)
+  end
+
+  def test_sentinels_empty
+    ['', []].each do |sentinels_val|
+      config_obj = {
+        url: 'redis://master-group-name',
+        sentinels: sentinels_val
+      }
+      redis_cfg = Storage::Helpers.config_with(config_obj)
+      refute redis_cfg.key?(:sentinels)
+    end
+  end
+
+  def test_redis_no_scheme
+    assert_nothing_raised do
+      StorageAsync::Client.send :new, url('backend-redis:6379')
+    end
+  end
+  
+  private
+
+  def assert_connection(client)
+    client.flushdb
+    client.set('foo', 'bar')
+    assert_equal 'bar', client.get('foo')
+  end
+
+  def assert_sentinel_client(client)
+    inner_client = client.instance_variable_get(:@inner).instance_variable_get(:@redis_async)
+    assert_instance_of Async::Redis::SentinelsClient, inner_client
+  end
+
+  def assert_sentinel_config(conn, url:, **conf)
+    client = conn.instance_variable_get(:@inner).instance_variable_get(:@redis_async)
+    uri = URI(url || '')
+    name = uri.host
+    role = conf[:role] || :master
+    password = client.instance_variable_get(:@protocol).instance_variable_get(:@password)
+
+    assert_equal name, client.instance_variable_get(:@master_name)
+    assert_equal role, client.instance_variable_get(:@role)
+
+    assert_equal conf[:sentinels].size, client.instance_variable_get(:@sentinel_endpoints).size
+    client.instance_variable_get(:@sentinel_endpoints).each_with_index do |endpoint, i|
+      host, port = endpoint.address
+      assert_equal conf[:sentinels][i][:host], host
+      assert_equal conf[:sentinels][i][:port], port
+      assert_equal(conf[:sentinels][i][:password], password) if conf[:sentinels][i].key? :password
+    end unless conf[:sentinels].empty?
+  end
+
+  def url(url)
+    Storage::Helpers.config_with({ url: url })
+  end
+end


### PR DESCRIPTION
Sentinels are not supported in asnyc mode. This adds support by using `Async::Redis::SentinelClient`

Jira: [THREESCALE-10605](https://issues.redhat.com/browse/THREESCALE-10605)

**How to verify:**

1. Follow the instructions from https://github.com/socketry/async-redis/pull/29 to launch the sentinels
2. Set the next variables in the .env file:
```
CONFIG_QUEUES_MASTER_NAME=redis://mymaster
CONFIG_QUEUES_SENTINEL_HOSTS=redis://localhost:9000,redis://localhost:9001,redis://localhost:9002
CONFIG_REDIS_PROXY=redis://mymaster
CONFIG_REDIS_SENTINEL_HOSTS=redis://localhost:9000,redis://localhost:9001,redis://localhost:9002
```
3. Launch the worker and the listener.
4. Launch all other tools: server, sidekiq, sphinx, apicast, etc.
5. `curl` apicast and check from porta that hits are being registered properly