### PR TITLE
THREESCALE-10697: Add debug mode for the worker and add RubyMine configurations for both worker and listener

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -202,3 +202,41 @@ Additional information which is really important to how the application runs can
 be found in the manifest:
 
 > `$ bundle exec 3scale_backend manifest`
+
+## Running from your IDE
+
+Some IDEs like VSCode or RubyMine allow to add custom launchers for scripts. This is convenient to launch both Worker and Listener.
+
+For that, you'll need to create the following configurations: 
+
+### Worker
+
+| Field                 | Value                                                   |
+|-----------------------|---------------------------------------------------------|
+| Name                  | `worker`                                                |
+| Ruby script           | `/path/to/project/apisonator/bin/3scale_backend_worker` |
+| Script arguments      | `--debug`                                               |
+| Working directory     | `/path/to/project/apisonator`                           |
+| Environment variables | `RACK_ENV=development`                                  |
+
+In case you want to run the worker in async mode you can add `CONFIG_REDIS_ASYNC=true` to the environment variables here or directly add it to your `.env` file.
+
+### Puma Listener (sync mode)
+
+| Field                 | Value                                            |
+|-----------------------|--------------------------------------------------|
+| Name                  | `listener (puma)`                                |
+| Ruby script           | `/path/to/project/apisonator/bin/3scale_backend` |
+| Script arguments      | `-s puma -X start -p 3001`                       |
+| Working directory     | `/path/to/project/apisonator`                    |
+| Environment variables | `RACK_ENV=development`        |
+
+### Falcon Listener (async mode)
+
+| Field                 | Value                                                             |
+|-----------------------|-------------------------------------------------------------------|
+| Name                  | `listener (falcon)`                                               |
+| Ruby script           | `/path/to/project/apisonator/bin/3scale_backend`                  |
+| Script arguments      | `-s falcon start -p 3001`                                         |
+| Working directory     | `/path/to/project/apisonator`                                     |
+| Environment variables | `RACK_ENV=development;CONFIG_REDIS_ASYNC=true` |

--- a/bin/3scale_backend_worker
+++ b/bin/3scale_backend_worker
@@ -1,26 +1,39 @@
 #!/usr/bin/env ruby
 require '3scale/backend'
+require '3scale/backend/job_fetcher'
 require 'daemons'
+
+def debug
+  ThreeScale::Backend::Worker.work(job_fetcher: ThreeScale::Backend::JobFetcher.new(fetch_timeout: 1))
+end
+
+def production
+  options = {
+    multiple: true,
+    dir_mode: :normal,
+    dir: "#{ENV['WORKER_PIDFILE_DIR'] || '/var/run/3scale'}"
+  }
+
+  # make --no-daemonize an alias of --ontop
+  options[:ontop] = true if ARGV.delete '--no-daemonize'
+
+  if !File.writable? options[:dir]
+    require 'fileutils'
+    FileUtils.mkdir_p options[:dir]
+  end
+
+  Daemons.run_proc('3scale_backend_worker', options) do
+    ThreeScale::Backend::Worker.work
+  end
+end
 
 if ARGV.delete '--version'
   STDOUT.puts "3scale_backend_worker version #{ThreeScale::Backend::VERSION}"
   exit 0
 end
 
-options = {
-  multiple: true,
-  dir_mode: :normal,
-  dir: '/var/run/3scale'
-}
-
-# make --no-daemonize an alias of --ontop
-options[:ontop] = true if ARGV.delete '--no-daemonize'
-
-if !File.writable? options[:dir]
-  require 'fileutils'
-  FileUtils.mkdir_p options[:dir]
-end
-
-Daemons.run_proc('3scale_backend_worker', options) do
-  ThreeScale::Backend::Worker.work
+if ARGV.delete '--debug'
+  debug
+else
+  production
 end


### PR DESCRIPTION
**What this PR does / why we need it**
This PR adds a debug mode for the worker and suggest RubyMine configs for both worker and listeners so developers can easily configure them in their RubyMine scripts. It comes from the request in #352, which suggested to create some scripts, but simplifies the process (thanks @mayorova).

**Verification steps**
Following the proposed configurations at `DEVELOPMENT.md` create the three RubyMine configurations.

Then launch both worker a listener in debug mode with a breaking point and confirm it's working. 