### PR TITLE
Bump json to 2.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     hiredis (0.6.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    json (2.3.1)
+    json (2.5.1)
     license_finder (7.1.0)
       bundler
       rubyzip (>= 1, < 3)


### PR DESCRIPTION
**What this PR does**
Bumps `json` gem to 2.5.1.

**Why we need it** 
Ruby 3.0.X has `json 2.5.1` as the [default gem](https://stdgems.org/json/), however we're currently using `2.3.1` so this PR updates the Gemfile to align with that. It will also solve our current problem with RubyMine debugger, since it will resolve the actual conflict with the default `json`.