### PR TITLE
Disable path traversal protection on internal API to allow slashes in app IDs

### DIFF
--- a/app/api/internal/internal.rb
+++ b/app/api/internal/internal.rb
@@ -19,6 +19,8 @@ module ThreeScale
 
         register Sinatra::Namespace
 
+        set :protection, except: :path_traversal
+
         # using a class variable instead of settings because we want this to be
         # as fast as possible when responding, since we hit /status a lot.
         @@status = { status: :ok,


### PR DESCRIPTION
This is related to https://github.com/3scale/pisoni/pull/33

Currently, when app IDs or app keys have slashes in them, either `/` or `\`, the API doesn't work as intended. This is because `rack-protection`'s path traversal 


so, the ID one/two\three (in Ruby "one/two\\three") is encoded by pisoni correctly into one%2Ftwo%5Cthree, but the [path traversal](https://github.com/sinatra/sinatra/blob/v2.2.4/rack-protection/lib/rack/protection/path_traversal.rb#L28-L29) decodes encoded slashes, and also replaces `\` with `/` **before** routing takes place, so the path ends up completely wrong.
So, for example for an app with app ID and app key which is `one/two\three`, the path gets converted from
```
/internal/services/500/applications/one%2Ftwo%5Cthree/keys/one%2Ftwo%5Cthree
```
to
```
/internal/services/500/applications/one/two/thee/keys/one/two/thee
```

I believe disabling path traversal protection is only an issue when the application serves static files. I think we are pretty confident that this would not happen on the backend Internal API, so I think that's OK.

Alternatively, we can just disallow both backward and forward slashes (the forward ones are already disallowed in porta), but it may not be ideal in case OpenID connect is used with an SSO provider that generates client secrets with special characters including slashes.