### PR TITLE
Fix dotenv on staging

### DIFF
--- a/lib/3scale/dotenv.rb
+++ b/lib/3scale/dotenv.rb
@@ -1,6 +1,6 @@
 # Ensure the proper .env file is loaded
 #
-# Don't load any .env file for production
+# Don't load any .env file for production or staging
 # First, try to load `.env.#{ENV['RACK_ENV']}`
 # If doesn't exist, try to load .env.test
 # If doesn't exist, try to load .env
@@ -12,7 +12,7 @@ def env_file
 end
 
 begin
-  return if ENV['RACK_ENV'] == 'production'
+  return if %w(staging production).include?(ENV['RACK_ENV'])
 
   require 'dotenv'
 

--- a/lib/3scale/dotenv.rb
+++ b/lib/3scale/dotenv.rb
@@ -5,9 +5,7 @@
 # If doesn't exist, try to load .env.test
 def env_file
   file = ".env.#{ENV['RACK_ENV']}"
-  return file if File.exists?(file)
-
-  '.env.test'
+  File.exists?(file) ? file : '.env.test'
 end
 
 begin

--- a/lib/3scale/dotenv.rb
+++ b/lib/3scale/dotenv.rb
@@ -3,12 +3,11 @@
 # Don't load any .env file for production or staging
 # First, try to load `.env.#{ENV['RACK_ENV']}`
 # If doesn't exist, try to load .env.test
-# If doesn't exist, try to load .env
 def env_file
   file = ".env.#{ENV['RACK_ENV']}"
   return file if File.exists?(file)
 
-  File.exists?('.env.test') ? '.env.test' : '.env'
+  '.env.test'
 end
 
 begin


### PR DESCRIPTION
We can't deploy to staging due to a bug on how we load dotenv files by priority.

This PR fixes that. Also, it simplifies the code by never trying to load the `.env` file, since it would never be loaded anyway, because `.env.test` has more priority and it's always present because it's in the repo.

So this is how it works now:

- It doesn't use dotenv at all in staging or production.
- It tries to load `.env.{RACK_ENV}`.
- If that fails, it loads `.env.test`.