### PR TITLE
Fix memory leak on the async worker

### DIFF
--- a/lib/3scale/backend/worker_async.rb
+++ b/lib/3scale/backend/worker_async.rb
@@ -79,7 +79,7 @@ module ThreeScale
           barrier.wait if barrier.size > semaphore.limit
         end
       ensure
-        barrier.stop
+        barrier.wait
       end
 
       def clear_queue
@@ -91,7 +91,6 @@ module ThreeScale
         end
       ensure
         barrier.wait
-        barrier.stop
       end
 
       def start_thread_to_fetch_jobs

--- a/lib/3scale/backend/worker_async.rb
+++ b/lib/3scale/backend/worker_async.rb
@@ -73,6 +73,9 @@ module ThreeScale
           break if @shutdown
 
           semaphore.async { perform(job) }
+
+          # Wait for the last `@max_concurrent_jobs` tasks to finish and clean the barrier.
+          # Otherwise it produces a memory leak. More info: https://github.com/3scale/apisonator/pull/376
           barrier.wait if barrier.size > semaphore.limit
         end
       ensure

--- a/lib/3scale/backend/worker_async.rb
+++ b/lib/3scale/backend/worker_async.rb
@@ -73,9 +73,10 @@ module ThreeScale
           break if @shutdown
 
           semaphore.async { perform(job) }
+          barrier.wait if barrier.size > semaphore.limit
         end
       ensure
-        barrier.wait
+        barrier.stop
       end
 
       def clear_queue
@@ -87,6 +88,7 @@ module ThreeScale
         end
       ensure
         barrier.wait
+        barrier.stop
       end
 
       def start_thread_to_fetch_jobs

--- a/lib/3scale/backend/worker_async.rb
+++ b/lib/3scale/backend/worker_async.rb
@@ -74,8 +74,9 @@ module ThreeScale
 
           semaphore.async { perform(job) }
 
-          # Wait for the last `@max_concurrent_jobs` tasks to finish and clean the barrier.
-          # Otherwise it produces a memory leak. More info: https://github.com/3scale/apisonator/pull/376
+          # Clean-up tasks inside barrier regularly, otherwise they accumulate throughout the worker lifetime
+          # and never GCed, eventually exhausting the whole available memory. Moreover the array keeping
+          # track of tasks in the barrier grows indefinitely too occupying memory and reducing performance.
           barrier.wait if barrier.size > semaphore.limit
         end
       ensure


### PR DESCRIPTION
According to some tests ran by the SRE team, the last alpha contains a memory leak. Check this comment: https://github.com/3scale/3scale-saas/issues/754#issuecomment-1984490467

After an investigation, I found the problem was produced by this commit: https://github.com/3scale/apisonator/commit/1d83cbd4728b5f4bbce0bdb1a727ecd7ddbe7437

And in particular, the leak is caused by the use of an `Async::Barrier` to force the `process_all` method to wait until all jobs are finished.

https://github.com/3scale/apisonator/blob/35731f9ba08e9cfb6d78ba14631fc851a66ff457/lib/3scale/backend/worker_async.rb#L61-L79

The `Async::Barrier` implementation is pretty simple, it's just an array `@tasks` of tasks that is being filled with a new task at every call to `async`. However, the tasks in this array aren't removed from it when the task finishes, instead, all tasks are removed at once when calling `wait`. See the code here: https://github.com/socketry/async/blob/v1.31.0/lib/async/barrier.rb

Since we only call `wait` once on the shutdown process, every one of the thousands of requests apisonator receives creates a task which is added to the barrier array and never removed, this is what produces the memory leak.

If you check the old worker code ([here](https://github.com/3scale/apisonator/blob/598e7225ac6d0af61dfb3b159961d7a0f420cd3e/lib/3scale/backend/worker_async.rb)) you can see how they tried to run the tasks in batches of `@max_concurrent_jobs` jobs. They called `schedule_jobs` to create `@max_concurrent_jobs` tasks and then called `@reactor.run` to run all of them. In my opinion, that was not working, because `@reactor.async { perform(job) }` actually runs the task, and `@reactor.run` does nothing. But I think the original idea of running tasks in batches of `@max_concurrent_jobs` tasks can work.

This PR adds one line that ensures that when there are more than `@max_concurrent_jobs` tasks in the barrier, no more tasks are scheduled and the current ones are waited to finish, thus removed from the barrier and fixing the memory leak.

This is how it worked before compared to now:

Before:
1. Up to 20 tasks are scheduled
2. One of them finishes
3. Another one takes the slot
4. Will always be 20 tasks being run concurrently

Now:
1. Up to 20 tasks are scheduled
2. Wait for all of them to finish
3. Accept 20 new tasks

In my tests this doesn't have any impact in performance, on the opposite, it seems to be faster now it doesn't have to work with that huge array.

This batching code is one possible approach to fix the leak, but I'm open to suggestions. Ideas?