### PR TITLE
Make dotenv gem available for all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ end
 
 group :development, :test do
   gem 'rspec_api_documentation', '~> 5.0'
-  gem 'dotenv', '~> 2.8.1'
 end
 
 # Default server by platform
@@ -73,3 +72,5 @@ gem 'webrick', '~> 1.8'
 # sentinels and avoids retrying calls when there's a timeout to prevent
 # duplicated commands. It's based on version 4.1.3.
 gem 'redis', git: 'https://github.com/3scale/redis-rb', branch: 'apisonator'
+
+gem 'dotenv', '~> 2.8.1'


### PR DESCRIPTION
The issue with having dotenv available only in `development` and `test` environments is that it is not available in the container image (because the bundler configuration excludes these two environments when installing the gems).

We use apisonator image to test [pisoni](https://github.com/3scale/pisoni) library, and the tests depend on having some [internal endpoints](https://github.com/search?q=repo%3A3scale%2Fapisonator%20define_private_endpoints%3F&type=code) that are only available in apisonator if `RACK_ENV` is `development` or `test`. These two environments try to load `dotenv`, but it's not available in the image.

So, the proposal is to make `dotenv` gem available in the apisonator image, but it should not affect the behavior, because it still [won't be required](https://github.com/3scale/apisonator/blob/35731f9ba08e9cfb6d78ba14631fc851a66ff457/lib/3scale/dotenv.rb#L12) in `production` and `staging`.
