### PR TITLE
Async mode: Add support for Redis logical DBs

### DIFF
--- a/lib/async/redis/protocol/extended_resp2.rb
+++ b/lib/async/redis/protocol/extended_resp2.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'async/redis/protocol/resp2'
+
+module Async
+  module Redis
+    module Protocol
+
+      # Custom Redis Protocol supporting Redis logical DBs
+      class ExtendedRESP2
+        def initialize(db: nil)
+          @db = db
+        end
+
+        def client(stream)
+          client = Async::Redis::Protocol::RESP2.client(stream)
+
+          if @db
+            client.write_request(["SELECT", @db])
+            client.read_response
+          end
+
+          client
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Now the Async mode supports Redis logical databases, and honors URLs like `redis://localhost:6379/6`

The support has been also added for sentinels. A typical config would look like this:

```ruby
CONFIG_REDIS_PROXY=redis://redis-master/6
CONFIG_REDIS_SENTINEL_HOSTS=redis://localhost:26379,redis://localhost:26380,redis://localhost:26381
```