### PR TITLE
THREESCALE-8404: Add ACL and TLS support for Redis

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     test-unit (3.5.7)
       power_assert
     thor (1.2.1)
-    tilt (2.1.0)
+    tilt (2.3.0)
     timecop (0.9.1)
     timers (4.3.5)
     tomlrb (2.0.3)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,50 +22,107 @@ variables.
 ###  CONFIG_REDIS_PROXY
 
 - Redis URL for the data DB.
-- Optional. Defaults to "redis://localhost:6379".
+- Optional. Defaults to `redis://localhost:6379`.
 - Applies to: listener, worker, cron.
 - Format: string.
+
+###  CONFIG_REDIS_USERNAME
+
+- Redis user name
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: string.
+
+###  CONFIG_REDIS_PASSWORD
+
+- Redis password
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: string.
+
+###  CONFIG_REDIS_SSL
+
+- Whether use SSL to connect to Redis
+- Optional. Defaults to not set
+- Will be considered `true` when the URL schema is `rediss`
+- Applies to: listener, worker, cron.
+- Format: `true` or `false`.
+
+###  CONFIG_REDIS_CA_FILE
+
+- Certification authority to validate Redis server TLS connections with
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: path to file as string.
+
+###  CONFIG_REDIS_CERT
+
+- The path to the client SSL certificate
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: path to file as string.
+
+###  CONFIG_REDIS_PRIVATE_KEY
+
+- The path to the client SSL private key
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: path to file as string.
 
 ###  CONFIG_REDIS_SENTINEL_HOSTS
 
 - URL of Redis sentinels.
 - Optional. Required only when using a Redis cluster with sentinels.
 - Applies to: listener, worker, cron.
-- Format: list of URLs separated by ",".
+- Format: list of URLs separated by `,`.
+
+### CONFIG_REDIS_SENTINEL_USERNAME
+
+- Sentinels user name
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: string.
+
+### CONFIG_REDIS_SENTINEL_PASSWORD
+
+- Sentinels password
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: string.
 
 ###  CONFIG_REDIS_SENTINEL_ROLE
 
 - Asks the sentinel for the URL of the master or a slave.
-- Optional. Defaults to master. Applies only when using a Redis cluster with
+- Optional. Defaults to `master`. Applies only when using a Redis cluster with
 sentinels.
 - Applies to: listener, worker, cron.
-- Format: master or slave.
+- Format: `master` or `slave`.
 
 ###  CONFIG_REDIS_CONNECT_TIMEOUT
 
 - Connect timeout.
-- Optional. Defaults to 5.
+- Optional. Defaults to `5`.
 - Applies to: listener, worker, cron.
 - Format: integer (seconds).
 
 ###  CONFIG_REDIS_READ_TIMEOUT
 
 - Read timeout.
-- Optional. Defaults to 3.
+- Optional. Defaults to `3`.
 - Applies to: listener, worker, cron.
 - Format: integer (seconds).
 
 ###  CONFIG_REDIS_WRITE_TIMEOUT
 
 - Write timeout.
-- Optional. Defaults to 3.
+- Optional. Defaults to `3`.
 - Applies to: listener, worker, cron.
 - Format: integer (seconds).
 
 ### CONFIG_REDIS_MAX_CONNS
 
 - Max number of connections.
-- Optional. Defaults to 10.
+- Optional. Defaults to `10`.
 - Applies to: listener, worker, cron.
 - Format: integer (seconds).
 
@@ -75,51 +132,108 @@ sentinels.
 ### CONFIG_QUEUES_MASTER_NAME
 
 - Redis URL for the queues DB.
-- Required when `RACK_ENV` is not "test" or "development". Defaults to
-"redis://localhost:6379" in those 2 environments.
+- Required when `RACK_ENV` is not `test` or `development`. Defaults to
+`redis://localhost:6379` in those 2 environments.
 - Applies to: listener, worker, cron.
 - Format: string.
+
+###  CONFIG_QUEUES_USERNAME
+
+- Redis user name
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: string.
+
+###  CONFIG_QUEUES_PASSWORD
+
+- Redis password
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: string.
+
+###  CONFIG_QUEUES_SSL
+
+- Whether use SSL to connect to Redis
+- Optional. Defaults to not set
+- Will be considered `true` when the URL schema is `rediss`
+- Applies to: listener, worker, cron.
+- Format: `true` or `false`.
+
+###  CONFIG_QUEUES_CA_FILE
+
+- Certification authority certificate Redis should trust to accept TLS connections
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: path to file as string.
+
+###  CONFIG_QUEUES_CERT
+
+- User certificate to connect to Redis through TLS
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: path to file as string.
+
+###  CONFIG_QUEUES_PRIVATE_KEY
+
+- User key to connect to Redis through TLS
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: path to file as string.
 
 ### CONFIG_QUEUES_SENTINEL_HOSTS
 
 - URL of Redis sentinels.
 - Optional. Required only when using a Redis cluster with sentinels.
 - Applies to: listener, worker, cron.
-- Format: list of URLs separated by ",".
+- Format: list of URLs separated by `,`.
+
+### CONFIG_QUEUES_SENTINEL_USERNAME
+
+- Sentinels user name
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: string.
+
+### CONFIG_QUEUES_SENTINEL_PASSWORD
+
+- Sentinels password
+- Optional. Defaults to not set.
+- Applies to: listener, worker, cron.
+- Format: string.
 
 ### CONFIG_QUEUES_SENTINEL_ROLE
 
 - Asks the sentinel for the URL of the master or a slave.
-- Optional. Defaults to master. Applies only when using a Redis cluster with
+- Optional. Defaults to `master`. Applies only when using a Redis cluster with
 sentinels.
 - Applies to: listener, worker, cron.
-- Format: master or slave.
+- Format: `master` or `slave`.
 
 ### CONFIG_QUEUES_CONNECT_TIMEOUT
 
 - Connect timeout.
-- Optional. Defaults to 5.
+- Optional. Defaults to `5`.
 - Applies to: listener, worker, cron.
 - Format: integer (seconds).
 
 ### CONFIG_QUEUES_READ_TIMEOUT
 
 - Read timeout.
-- Optional. Defaults to 3.
+- Optional. Defaults to `3`.
 - Applies to: listener, worker, cron.
 - Format: integer (seconds).
 
 ### CONFIG_QUEUES_WRITE_TIMEOUT
 
 - Write timeout.
-- Optional. Defaults to 3.
+- Optional. Defaults to `3`.
 - Applies to: listener, worker, cron.
 - Format: integer (seconds).
 
 ### CONFIG_QUEUES_MAX_CONNS
 
 - Max number of connections.
-- Optional. Defaults to 10.
+- Optional. Defaults to `10`.
 - Applies to: listener, worker, cron.
 - Format: integer (seconds).
 
@@ -129,14 +243,14 @@ sentinels.
 ### CONFIG_INTERNAL_API_USER
 
 - The user needed when sending requests to the internal API.
-- Required when `RACK_ENV` is "production", optional otherwise.
+- Required when `RACK_ENV` is `production`, optional otherwise.
 - Applies to: listener.
 - Format: string.
 
 ### CONFIG_INTERNAL_API_PASSWORD
 
 - The password needed when sending requests to the internal API.
-- Required when `RACK_ENV` is "production", optional otherwise.
+- Required when `RACK_ENV` is `production`, optional otherwise.
 - Applies to: listener.
 - Format: string.
 
@@ -167,7 +281,7 @@ account of Porta.
 
 - Name of the metric configured in the master account of Porta to track the
 number of report calls. Applies only when `CONFIG_MASTER_SERVICE_ID` is set.
-- Optional. Defaults to "transactions".
+- Optional. Defaults to `transactions`.
 - Applies to: listener.
 - Format: string.
 
@@ -175,7 +289,7 @@ number of report calls. Applies only when `CONFIG_MASTER_SERVICE_ID` is set.
 
 - Name of the metric configured in the master account of Porta to track the
 number of authorize calls. Applies only when `CONFIG_MASTER_SERVICE_ID` is set.
-- Optional. Defaults to "transactions/authorize".
+- Optional. Defaults to `transactions/authorize`.
 - Applies to: listener.
 - Format: string.
 
@@ -185,31 +299,31 @@ number of authorize calls. Applies only when `CONFIG_MASTER_SERVICE_ID` is set.
 ### CONFIG_LOG_PATH
 
 - Log path to write logs that are not request logs, like some kind of warnings.
-- Optional. Defaults to /dev/stdout.
+- Optional. Defaults to `/dev/stdout`.
 - Applies to: listener, worker, cron.
 - Format: string.
 
 ### CONFIG_REQUEST_LOGGERS
 
 - The format for request logs.
-- Optional. Defaults to "text".
+- Optional. Defaults to `text`.
 - Applies to: listener.
-- Format: the options are "text", "json", and "text,json". The last one will
+- Format: the options are `text`, `json`, and `text,json`. The last one will
 print the logs in both formats.
 
 ### CONFIG_WORKERS_LOG_FILE
 
 - Log path to write job logs (runtime, type of job, etc.)
-- Optional. Defaults to /dev/stdout.
+- Optional. Defaults to `/dev/stdout`.
 - Applies to: worker.
 - Format: string.
 
 ### CONFIG_WORKERS_LOGGER_FORMATTER
 
 - The format for the worker logs.
-- Optional. Defaults to "text".
+- Optional. Defaults to `text`.
 - Applies to: worker.
-- Format: the options are "text" and "json".
+- Format: the options are `text` and `json`.
 
 
 ## Prometheus metrics
@@ -217,28 +331,28 @@ print the logs in both formats.
 ### CONFIG_LISTENER_PROMETHEUS_METRICS_ENABLED
 
 - Enables prometheus metrics on the listener.
-- Optional. Defaults to false.
+- Optional. Defaults to `false`.
 - Applies to: listener.
-- Format: true or false.
+- Format: `true` or `false`.
 
 ### CONFIG_LISTENER_PROMETHEUS_METRICS_PORT
 
 - Port of the Prometheus metrics server of the listener.
-- Optional. Defaults to 9394.
+- Optional. Defaults to `9394`.
 - Applies to: listener.
 - Format: integer.
 
 ### CONFIG_WORKER_PROMETHEUS_METRICS_ENABLED
 
 - Enables prometheus metrics on the worker.
-- Optional. Defaults to false.
+- Optional. Defaults to `false`.
 - Applies to: worker.
-- Format: true or false.
+- Format: `true` or `false`.
 
 ### CONFIG_WORKER_PROMETHEUS_METRICS_PORT
 
 - Port of the Prometheus metrics server of the worker.
-- Optional. Defaults to 9394.
+- Optional. Defaults to `9394`.
 - Applies to: worker.
 - Format: integer.
 
@@ -250,9 +364,9 @@ print the logs in both formats.
 - Selects the implementation of the referrer filter validator. When set to true,
 the validator behaves like an old version of the filter. This should only be
 used in Apisonator instances witch customers that rely on that behaviour.
-- Optional. Defaults to false.
+- Optional. Defaults to `false`.
 - Applies to: listener.
-- Format: true or false.
+- Format: `true` or `false`.
 
 
 ## Async
@@ -260,21 +374,21 @@ used in Apisonator instances witch customers that rely on that behaviour.
 ### CONFIG_REDIS_ASYNC
 
 - Enables the [async mode](async.md).
-- Optional. Defaults to false.
+- Optional. Defaults to `false`.
 - Applies to: listener, worker, cron.
-- Format: true or false.
+- Format: `true` or `false`.
 
 ### CONFIG_ASYNC_WORKER_MAX_CONCURRENT_JOBS
 
 - Max number of jobs in the reactor.
-- Optional. Defaults to 20. Applies only when `CONFIG_REDIS_ASYNC=true`.
+- Optional. Defaults to `20`. Applies only when `CONFIG_REDIS_ASYNC=true`.
 - Applies to: worker.
 - Format: integer.
 
 ### CONFIG_ASYNC_WORKER_MAX_PENDING_JOBS
 
 - Max number of jobs in memory pending to be added to the reactor.
-- Optional. Defaults to 100. Applies only when `CONFIG_REDIS_ASYNC=true`.
+- Optional. Defaults to `100`. Applies only when `CONFIG_REDIS_ASYNC=true`.
 - Applies to: worker.
 - Format: integer.
 
@@ -282,7 +396,7 @@ used in Apisonator instances witch customers that rely on that behaviour.
 
 - Seconds to wait before fetching more jobs when the number of jobs
 in memory has reached max_pending_jobs.
-- Optional. Defaults to 0.01. Applies only when `CONFIG_REDIS_ASYNC=true`.
+- Optional. Defaults to `0.01`. Applies only when `CONFIG_REDIS_ASYNC=true`.
 - Applies to: worker.
 - Format: float (in seconds).
 
@@ -291,17 +405,17 @@ in memory has reached max_pending_jobs.
 
 ### CONFIG_NOTIFICATION_BATCH
 
-- Apisonator creates NotifyJobs to update the "transactions" and
-"transactions/authorize" metrics. This env defines how many updates include on
+- Apisonator creates NotifyJobs to update the `transactions` and
+`transactions/authorize metrics`. This env defines how many updates include on
 each job.
-- Optional. Defaults to 10000.
+- Optional. Defaults to `10000`.
 - Applies to: listener.
 - Format: integer.
 
 ### LISTENER_WORKERS
 
 - Number of worker processes of the listener.
-- Optional. Defaults to the number of CPUs * 8.
+- Optional. Defaults to the `number of CPUs * 8`.
 - Applies to: listener.
 - Format: integer.
 
@@ -315,14 +429,14 @@ each job.
 ### RESCHEDULE_JOBS_FREQ
 
 - Frequency of the task that reschedules failed jobs.
-- Optional. Defaults to 300.
+- Optional. Defaults to `300`.
 - Applies to: cron.
 - Format: integer (seconds).
 
 ### DELETE_STATS_FREQ
 
 - How often to delete the stats of deleted services.
-- Optional. Defaults to 86400 (one day).
+- Optional. Defaults to `86400` (one day).
 - Applies to: cron.
 - Format: integer (seconds).
 
@@ -332,11 +446,11 @@ each job.
 
 - Used to enable/disable some features, mainly it's used to expose some
 functions that are only useful when running the test suite.
-- Optional: defaults to "development".
+- Optional: defaults to `development`.
 - Applies to: listener, worker, cron.
-- Format: "development", "test", "production". When set to any other value, it
-will act as "development". Also, the error reporting service might use this to
-distinguish between "production" and "staging" for example.
+- Format: `development`, `test`, `production`. When set to any other value, it
+will act as `development`. Also, the error reporting service might use this to
+distinguish between `production` and `staging` for example.
 
 
 ## External error reporting

--- a/lib/3scale/backend/async_redis/client.rb
+++ b/lib/3scale/backend/async_redis/client.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Based on https://github.com/socketry/async-redis/blob/v0.8.1/examples/auth/wrapper.rb
+
+require 'async/redis/client'
+require '3scale/backend/async_redis/endpoint_helpers'
+require '3scale/backend/async_redis/sentinels_client_acl_tls'
+require '3scale/backend/async_redis/protocol/extended_resp2'
+
+module ThreeScale
+  module Backend
+    module AsyncRedis
+      # Friendly client wrapper that supports SSL, AUTH and db SELECT
+      class Client
+        class << self
+          # @param opts [Hash] Redis connection options
+          # @return [Async::Redis::Client]
+          def call(opts)
+            uri = URI(opts[:url])
+
+            credentials = [ uri.user || opts[:username], uri.password || opts[:password]]
+            db = uri.path[1..-1].to_i if uri.path
+
+            protocol = Protocol::ExtendedRESP2.new(db: db, credentials: credentials)
+
+            if opts.key? :sentinels
+              SentinelsClientACLTLS.new(uri, protocol, opts)
+            else
+              host = uri.host || EndpointHelpers::DEFAULT_HOST
+              port = uri.port || EndpointHelpers::DEFAULT_PORT
+              endpoint = EndpointHelpers.prepare_endpoint(host, port, opts[:ssl], opts[:ssl_params])
+              Async::Redis::Client.new(endpoint, protocol: protocol, limit: opts[:max_connections])
+            end
+          end
+          alias :connect :call
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale/backend/async_redis/endpoint_helpers.rb
+++ b/lib/3scale/backend/async_redis/endpoint_helpers.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'async/io'
+
+module ThreeScale
+  module Backend
+    module AsyncRedis
+      module EndpointHelpers
+
+        DEFAULT_HOST = 'localhost'.freeze
+        DEFAULT_PORT = 6379
+
+        class << self
+
+          # @param host [String]
+          # @param port [Integer]
+          # @param ssl_params [Hash]
+          # @return [Async::IO::Endpoint::Generic]
+          def prepare_endpoint(host, port, ssl = false, ssl_params = nil)
+            tcp_endpoint = Async::IO::Endpoint.tcp(host, port)
+
+            if ssl
+              ssl_context = OpenSSL::SSL::SSLContext.new
+              ssl_context.set_params(format_ssl_params(ssl_params)) if ssl_params
+              return Async::IO::SSLEndpoint.new(tcp_endpoint, ssl_context: ssl_context)
+            end
+
+            tcp_endpoint
+          end
+
+          def format_ssl_params(ssl_params)
+            cert = ssl_params[:cert].to_s.strip
+            key = ssl_params[:key].to_s.strip
+            return ssl_params if cert.empty? && key.empty?
+
+            updated_ssl_params = ssl_params.dup
+            updated_ssl_params[:cert] = OpenSSL::X509::Certificate.new(File.read(cert))
+            updated_ssl_params[:key] = OpenSSL::PKey.read(File.read(key))
+
+            updated_ssl_params
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale/backend/async_redis/protocol/extended_resp2.rb
+++ b/lib/3scale/backend/async_redis/protocol/extended_resp2.rb
@@ -8,13 +8,21 @@ module ThreeScale
       module Protocol
 
         # Custom Redis Protocol supporting Redis logical DBs
+        # and ACL credentials
         class ExtendedRESP2
-          def initialize(db: nil)
+
+          def initialize(db: nil, credentials: [])
             @db = db
+            @credentials = credentials
           end
 
           def client(stream)
             client = Async::Redis::Protocol::RESP2.client(stream)
+
+            if @credentials.any?
+              client.write_request(["AUTH", *@credentials])
+              client.read_response # Ignore response.
+            end
 
             if @db
               client.write_request(["SELECT", @db])

--- a/lib/3scale/backend/async_redis/sentinels_client_acl_tls.rb
+++ b/lib/3scale/backend/async_redis/sentinels_client_acl_tls.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'openssl'
+require 'async/redis/sentinels'
+
+module ThreeScale
+  module Backend
+    module AsyncRedis
+      class SentinelsClientACLTLS < Async::Redis::SentinelsClient
+        def initialize(uri, protocol = Async::Redis::Protocol::RESP2, config, **options)
+          @master_name = uri.host
+          @sentinel_endpoints = config[:sentinels].map do |sentinel|
+            EndpointHelpers.prepare_endpoint(sentinel[:host], sentinel[:port], config[:ssl], config[:ssl_params])
+          end
+          @role = config[:role] || :master
+
+          @sentinel_credentials = config[:sentinel_username], config[:sentinel_password]
+          @protocol = protocol
+          @config = config
+          @pool = connect(**options)
+        end
+
+        private
+
+        def resolve_master
+          @sentinel_endpoints.each do |sentinel_endpoint|
+            client = Async::Redis::Client.new(sentinel_endpoint, protocol: Protocol::ExtendedRESP2.new(credentials: @sentinel_credentials))
+
+            begin
+              address = client.call('sentinel', 'get-master-addr-by-name', @master_name)
+            rescue Errno::ECONNREFUSED
+              next
+            end
+
+            return EndpointHelpers.prepare_endpoint(address[0], address[1], @config[:ssl], @config[:ssl_params]) if address
+          end
+
+          nil
+        end
+
+        def resolve_slave
+          @sentinel_endpoints.each do |sentinel_endpoint|
+            client = Async::Redis::Client.new(sentinel_endpoint, protocol: Protocol::ExtendedRESP2.new(credentials: @sentinel_credentials))
+
+            begin
+              reply = client.call('sentinel', 'slaves', @master_name)
+            rescue Errno::ECONNREFUSED
+              next
+            end
+
+            slaves = available_slaves(reply)
+            next if slaves.empty?
+
+            slave = select_slave(slaves)
+            return EndpointHelpers.prepare_endpoint(slave['ip'], slave['port'], @config[:ssl], @config[:ssl_params])
+          end
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/3scale/backend/configuration.rb
+++ b/lib/3scale/backend/configuration.rb
@@ -39,11 +39,12 @@ module ThreeScale
       config.workers_logger_formatter = :text
 
       # Add configuration sections
-      config.add_section(:queues, :master_name, :sentinels, :role,
-                         :connect_timeout, :read_timeout, :write_timeout, :max_connections)
-      config.add_section(:redis, :url, :proxy, :sentinels, :role,
-                         :connect_timeout, :read_timeout, :write_timeout, :max_connections,
-                         :async)
+      config.add_section(:queues, :master_name, :username, :password, :ssl, :ssl_params, :sentinels,
+                         :sentinel_username, :sentinel_password, :role, :connect_timeout, :read_timeout, :write_timeout,
+                         :max_connections)
+      config.add_section(:redis, :url, :proxy, :username, :password, :ssl, :ssl_params, :sentinels,
+                         :sentinel_username, :sentinel_password, :role, :connect_timeout, :read_timeout, :write_timeout,
+                         :max_connections, :async)
       config.add_section(:hoptoad, :service, :api_key)
       config.add_section(:internal_api, :user, :password)
       config.add_section(:master, :metrics)

--- a/lib/3scale/backend/storage_helpers.rb
+++ b/lib/3scale/backend/storage_helpers.rb
@@ -62,7 +62,8 @@ module ThreeScale
           # CONN_WHITELIST - Connection options that can be specified in config
           # Note: we don't expose reconnect_attempts until the bug above is fixed
           CONN_WHITELIST = [
-            :connect_timeout, :read_timeout, :write_timeout, :max_connections
+            :connect_timeout, :read_timeout, :write_timeout, :max_connections, :username, :password, :sentinel_username,
+            :sentinel_password, :ssl, :ssl_params
           ].freeze
           private_constant :CONN_WHITELIST
 
@@ -185,6 +186,7 @@ module ThreeScale
 
           def cfg_compact(options)
             empty = ->(_k,v) { v.to_s.strip.empty? }
+            options[:ssl_params]&.delete_if(&empty)
             options.delete_if(&empty)
           end
 
@@ -278,7 +280,8 @@ module ThreeScale
           def cfg_defaults_handler(options, defaults)
             cfg_with_defaults = defaults.merge(ensure_url_param(options))
             cfg_with_defaults = cfg_unix_path_handler(cfg_with_defaults)
-            cfg_with_defaults&.delete(:max_connections) unless options[:async]
+            cfg_with_defaults.delete(:max_connections) unless options[:async]
+            cfg_with_defaults[:ssl] ||= true if URI(options[:url].to_s).scheme == 'rediss'
             cfg_with_defaults
           end
 

--- a/openshift/3scale_backend.conf
+++ b/openshift/3scale_backend.conf
@@ -22,14 +22,34 @@ ThreeScale::Backend.configure do |config|
   config.internal_api.user = "#{ENV['CONFIG_INTERNAL_API_USER']}"
   config.internal_api.password = "#{ENV['CONFIG_INTERNAL_API_PASSWORD']}"
   config.queues.master_name = "#{ENV['CONFIG_QUEUES_MASTER_NAME']}"
+  config.queues.username = "#{ENV['CONFIG_QUEUES_USERNAME']}"
+  config.queues.password = "#{ENV['CONFIG_QUEUES_PASSWORD']}"
+  config.queues.ssl =  parse_boolean_env('CONFIG_QUEUES_SSL')
+  config.queues.ssl_params = {
+    ca_file: "#{ENV['CONFIG_QUEUES_CA_FILE']}",
+    cert: "#{ENV['CONFIG_QUEUES_CERT']}",
+    key: "#{ENV['CONFIG_QUEUES_PRIVATE_KEY']}"
+  }
   config.queues.sentinels = "#{ENV['CONFIG_QUEUES_SENTINEL_HOSTS'] && !ENV['CONFIG_QUEUES_SENTINEL_HOSTS'].empty? ? ENV['CONFIG_QUEUES_SENTINEL_HOSTS'] : ENV['SENTINEL_HOSTS']}"
+  config.queues.sentinel_username = "#{ENV['CONFIG_QUEUES_SENTINEL_USERNAME']}"
+  config.queues.sentinel_password = "#{ENV['CONFIG_QUEUES_SENTINEL_PASSWORD']}"
   config.queues.role = "#{ENV['CONFIG_QUEUES_SENTINEL_ROLE']}".to_sym
   config.queues.connect_timeout = parse_int_env('CONFIG_QUEUES_CONNECT_TIMEOUT')
   config.queues.read_timeout = parse_int_env('CONFIG_QUEUES_READ_TIMEOUT')
   config.queues.write_timeout = parse_int_env('CONFIG_QUEUES_WRITE_TIMEOUT')
   config.queues.max_connections = parse_int_env('CONFIG_QUEUES_MAX_CONNS')
   config.redis.proxy = "#{ENV['CONFIG_REDIS_PROXY']}"
+  config.redis.username = "#{ENV['CONFIG_REDIS_USERNAME']}"
+  config.redis.password = "#{ENV['CONFIG_REDIS_PASSWORD']}"
+  config.redis.ssl =  parse_boolean_env('CONFIG_REDIS_SSL')
+  config.redis.ssl_params = {
+      ca_file: "#{ENV['CONFIG_REDIS_CA_FILE']}",
+      cert: "#{ENV['CONFIG_REDIS_CERT']}",
+      key: "#{ENV['CONFIG_REDIS_PRIVATE_KEY']}"
+    }
   config.redis.sentinels = "#{ENV['CONFIG_REDIS_SENTINEL_HOSTS']}"
+  config.redis.sentinel_username = "#{ENV['CONFIG_REDIS_SENTINEL_USERNAME']}"
+  config.redis.sentinel_password = "#{ENV['CONFIG_REDIS_SENTINEL_PASSWORD']}"
   config.redis.role = "#{ENV['CONFIG_REDIS_SENTINEL_ROLE']}".to_sym
   config.redis.connect_timeout = parse_int_env('CONFIG_REDIS_CONNECT_TIMEOUT')
   config.redis.read_timeout = parse_int_env('CONFIG_REDIS_READ_TIMEOUT')

--- a/spec/unit/queue_storage_spec.rb
+++ b/spec/unit/queue_storage_spec.rb
@@ -45,7 +45,7 @@ module ThreeScale
       def is_sentinel?(connection)
         if ThreeScale::Backend.configuration.redis.async
           connector = connection.instance_variable_get(:@redis_async)
-          connector.instance_of?(Async::Redis::SentinelsClient)
+          connector.instance_of?(ThreeScale::Backend::AsyncRedis::SentinelsClientACLTLS)
         else
           connector = connection.instance_variable_get(:@client)
                                 .instance_variable_get(:@config)

--- a/test/test_helpers/certificates.rb
+++ b/test/test_helpers/certificates.rb
@@ -1,0 +1,67 @@
+# Copyright © 2020 Nicky Peeters
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require 'rubygems'
+require 'openssl'
+
+module TestHelpers
+  module Certificates
+    def create_key(alg)
+      case alg
+      when :rsa
+        OpenSSL::PKey::RSA.new(2048)
+      when :dsa
+        OpenSSL::PKey::DSA.new(2048)
+      when :ec
+        OpenSSL::PKey::EC.generate("prime256v1")
+      end
+    end
+
+    def create_cert(key = create_key(:rsa))
+      public_key = get_public_key(key)
+
+      subject = "/C=BE/O=Test/OU=Test/CN=Test"
+
+      cert = OpenSSL::X509::Certificate.new
+      cert.subject = cert.issuer = OpenSSL::X509::Name.parse(subject)
+      cert.not_before = Time.now
+      cert.not_after = Time.now + 365 * 24 * 60 * 60
+      cert.public_key = public_key
+      cert.serial = 0x0
+      cert.version = 2
+
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = cert
+      ef.issuer_certificate = cert
+      cert.extensions = [
+        ef.create_extension("basicConstraints","CA:TRUE", true),
+        ef.create_extension("subjectKeyIdentifier", "hash"),
+      # ef.create_extension("keyUsage", "cRLSign,keyCertSign", true),
+      ]
+      cert.add_extension ef.create_extension("authorityKeyIdentifier",
+                                             "keyid:always,issuer:always")
+
+      cert.sign key, (key.is_a?(OpenSSL::PKey::DSA) ? OpenSSL::Digest::SHA1.new : OpenSSL::Digest::SHA512.new)
+      cert
+    end
+
+    private
+
+    def get_public_key(key)
+      return OpenSSL::PKey::EC.new key if key.is_a? OpenSSL::PKey::EC
+
+      key.public_key
+    end
+  end
+end

--- a/test/unit/storage_async_test.rb
+++ b/test/unit/storage_async_test.rb
@@ -1,7 +1,10 @@
+require 'tempfile'
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 require '3scale/backend/storage_async'
 
 class StorageAsyncTest < Test::Unit::TestCase
+  include TestHelpers::Certificates
+
   def test_basic_operations
     storage = StorageAsync::Client.instance(true)
     storage.del('foo')
@@ -32,6 +35,11 @@ class StorageAsyncTest < Test::Unit::TestCase
     assert_raise Storage::InvalidURI do
       StorageAsync::Client.send :new, url('a_malformed_url:1:10')
     end
+  end
+
+  def test_redis_no_scheme
+    storage = StorageAsync::Client.send :new, url('backend-redis')
+    assert_client_config({ url: URI('redis://backend-redis:6379') }, storage)
   end
 
   def test_sentinels_connection_string
@@ -182,30 +190,154 @@ class StorageAsyncTest < Test::Unit::TestCase
     end
   end
 
-  def test_redis_no_scheme
-    storage = StorageAsync::Client.send :new, url('backend-redis')
-    assert_client_config({ url: URI('redis://backend-redis:6379') }, storage)
+  def test_sentinels_acl
+    config_obj = {
+      url: 'redis://master-group-name',
+      sentinels: 'redis://127.0.0.1:26379, redis://127.0.0.1:36379, redis://127.0.0.1:46379',
+      username: 'apisonator-test',
+      password: 'p4ssW0rd',
+      sentinel_username: 'sentinel-test',
+      sentinel_password: 'p4ssW0rd#'
+    }
+
+    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_config({ **config_obj,
+                             sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                                         { host: '127.0.0.1', port: 36_379 },
+                                         { host: '127.0.0.1', port: 46_379 }]},
+                           conn)
+  end
+
+  def test_sentinels_acl_tls
+    ca_file, cert, key = create_certs(:rsa).values_at(:ca_file, :cert, :key)
+
+    config_obj = {
+      url: 'rediss://master-group-name',
+      sentinels: 'rediss://127.0.0.1:26379, rediss://127.0.0.1:36379, rediss://127.0.0.1:46379',
+      username: 'apisonator-test',
+      password: 'p4ssW0rd',
+      sentinel_username: 'sentinel-test',
+      sentinel_password: 'p4ssW0rd#',
+      ssl_params: {
+        ca_file: ca_file.path,
+        cert: cert.path,
+        key: key.path
+      }
+    }
+
+    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_sentinel_config({ **config_obj,
+                             sentinels: [{ host: '127.0.0.1', port: 26_379 },
+                                         { host: '127.0.0.1', port: 36_379 },
+                                         { host: '127.0.0.1', port: 46_379 }]},
+                           conn, :rsa)
+  ensure
+    [ca_file, cert, key].each(&:unlink)
+  end
+
+  def test_tls_no_client_certificate
+    config_obj = {
+      url: 'rediss://localhost:46379/0',
+      ssl_params: {
+        ca_file: File.expand_path(File.join(__FILE__, '..', '..', '..', 'script', 'config', 'ca-root-cert.pem'))
+      }
+    }
+    storage = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_client_config(config_obj, storage)
+  end
+
+  [:rsa, :dsa, :ec].each do |alg|
+    define_method "test_tls_client_cert_#{alg}" do
+      ca_file, cert, key = create_certs(alg).values_at(:ca_file, :cert, :key)
+
+      config_obj = {
+        url: 'rediss://localhost:46379/0',
+        ssl_params: {
+          ca_file: ca_file.path,
+          cert: cert.path,
+          key: key.path
+        }
+      }
+      storage = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+      assert_client_config(config_obj, storage, alg)
+    ensure
+      [ca_file, cert, key].each(&:unlink)
+    end
+  end
+
+  def test_acl
+    config_obj = {
+      url: 'redis://localhost:6379/0',
+      username: 'apisonator-test',
+      password: 'p4ssW0rd'
+    }
+    storage = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_client_config(config_obj, storage)
+  end
+
+  def test_acl_tls
+    ca_file, cert, key = create_certs(:rsa).values_at(:ca_file, :cert, :key)
+
+    config_obj = {
+      url: 'rediss://localhost:46379/0',
+      ssl_params: {
+        ca_file: ca_file.path,
+        cert: cert.path,
+        key: key.path
+      },
+      username: 'apisonator-test',
+      password: 'p4ssW0rd'
+    }
+    storage = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
+    assert_client_config(config_obj, storage)
+  ensure
+    [ca_file, cert, key].each(&:unlink)
   end
 
   private
 
-  def assert_client_config(conf, conn)
+  def create_certs(alg)
+    ca_cert_file = Tempfile.new('ca-root-cert.pem')
+    ca_cert_file.write(create_cert.to_pem)
+    ca_cert_file.flush
+    ca_cert_file.close
+
+    key = create_key alg
+    key_file = Tempfile.new("redis-#{alg}.pem")
+    key_file.write(key.to_pem)
+    key_file.flush
+    key_file.close
+
+    cert_file = Tempfile.new("redis-#{alg}.crt")
+    cert_file.write(create_cert(key).to_pem)
+    cert_file.flush
+    cert_file.close
+
+    { ca_file: ca_cert_file, cert: cert_file, key: key_file }
+  end
+
+  def assert_client_config(conf, conn, test_cert_type = nil)
     client = conn.instance_variable_get(:@redis_async)
 
     url = URI(conf[:url])
     host, port = client.endpoint.address
     assert_equal url.host, host
     assert_equal url.port, port
+
+    assert_acl_credentials(conf, client)
+    assert_tls_certs(conf, client, test_cert_type)
   end
 
-  def assert_sentinel_config(conf, conn)
+  def assert_sentinel_config(conf, conn, test_cert_type = nil)
     client = conn.instance_variable_get(:@redis_async)
     uri = URI(conf[:url] || '')
     name = uri.host
     role = conf[:role] || :master
-    password = client.instance_variable_get(:@protocol).instance_variable_get(:@password)
 
-    assert_instance_of Async::Redis::SentinelsClient, client
+    assert_instance_of ThreeScale::Backend::AsyncRedis::SentinelsClientACLTLS, client
+
+    assert_acl_credentials(conf, client)
+    assert_tls_certs(conf, client, test_cert_type)
 
     assert_equal name, client.instance_variable_get(:@master_name)
     assert_equal role, client.instance_variable_get(:@role)
@@ -215,8 +347,46 @@ class StorageAsyncTest < Test::Unit::TestCase
       host, port = endpoint.address
       assert_equal conf[:sentinels][i][:host], host
       assert_equal conf[:sentinels][i][:port], port
-      assert_equal(conf[:sentinels][i][:password], password) if conf[:sentinels][i].key? :password
     end unless conf[:sentinels].empty?
+  end
+
+  def assert_acl_credentials(conf, client)
+    if conf[:username].to_s.strip.empty? && conf[:password].to_s.strip.empty?
+      assert_nil conf[:username]
+      assert_nil conf[:password]
+    else
+      assert_instance_of ThreeScale::Backend::AsyncRedis::Protocol::ExtendedRESP2, client.protocol
+      username, password = client.protocol.instance_variable_get(:@credentials)
+      assert_equal conf[:username], username
+      assert_equal conf[:password], password
+    end
+
+    if conf[:sentinel_username].to_s.strip.empty? && conf[:sentinel_password].to_s.strip.empty?
+      assert_nil conf[:sentinel_username]
+      assert_nil conf[:sentinel_password]
+    else
+      sentinel_username, sentinel_password = client.instance_variable_get(:@sentinel_credentials)
+      assert_equal conf[:sentinel_username], sentinel_username
+      assert_equal conf[:sentinel_password], sentinel_password
+    end
+  end
+
+  def assert_tls_certs(conf, client, test_cert_type)
+    unless conf[:ssl_params].to_s.strip.empty?
+      endpoint = client.endpoint || client.instance_variable_get(:@sentinel_endpoints).first
+      assert_instance_of Async::IO::SSLEndpoint, endpoint
+      assert_equal conf[:ssl_params][:ca_file], endpoint.options[:ssl_context].send(:ca_file)
+      assert_instance_of(OpenSSL::X509::Certificate, endpoint.options[:ssl_context].cert) unless conf[:ssl_params][:cert].to_s.strip.empty?
+
+      unless test_cert_type.to_s.strip.empty?
+        expected_classes = {
+          rsa: OpenSSL::PKey::RSA,
+          dsa: OpenSSL::PKey::DSA,
+          ec: OpenSSL::PKey::EC,
+        }
+        assert_instance_of(expected_classes[test_cert_type], endpoint.options[:ssl_context].key) unless conf[:ssl_params][:key].to_s.strip.empty?
+      end
+    end
   end
 
   def url(url)


### PR DESCRIPTION
This supersedes https://github.com/3scale/apisonator/pull/350. That PR is too messy and contains a lot of wrong or outdated info.

### Jira Issue:
[THREESCALE-8404](https://issues.redhat.com/browse/THREESCALE-8404)

### Summary of changes:
- Implement support for ACL and TLS (https://github.com/3scale/apisonator/commit/914f97c59faf0be8cbdef5cf9323bccd640aaded):
  - The existing async client (`StorageAsync::Client`) is very simple now. It got too complex due to all scenarios it must support, so I extracted most of its logic to the new class `AsyncRedis::Client`.
  - `AsyncRedis::Client` is a wrapper for the two Redis clients we use in async mode: one for single instances and one for sentinels. This implements support for all possible scenarios.
  - `AsyncRedis::EndpointHelpers` is a utility module which contains some logic that is used from several places.
  - Our custom protocol `AsyncRedis::Protocol::ExtendedRESP2` now accepts ACL credentials.
  - We also use our own client for Sentinels: `AsyncRedis::SentinelsClientACLTLS` which extends the upstream client `Async::Redis::SentinelsClient` to add it ACL and TLS support.
- Add new ENV variables to configure ACL and TLS (https://github.com/3scale/apisonator/commit/8104713eb612f1d3f4d95f83f62d8a10fb80cb22):
  - These new variables are going to be set directly from the operator.
  - Check: [THREESCALE-11020](https://issues.redhat.com/browse/THREESCALE-11020) and [THREESCALE-11021](https://issues.redhat.com/browse/THREESCALE-11021).
- Update tests (https://github.com/3scale/apisonator/commit/a7ddc79e76a84ca5ea762704f1edf874d25b25d8):
  - It installs `fakefs`. This is used to dynamically generate RSA, DSA and EC keys to be tested from `StorageAsyncTest`. In async mode we only support these 3 algorithms for TLS but I think that's enough for most of cases and we can add new algorithms in the future if some client requires it.
  - `TestHelpers::Certificates` contains the logic to generate keys and certificates for tests.
  - Added TLS and ACL tests in `StorageAsyncTest` and `StorageSyncTest`.