### PR TITLE
Remove empty credentials

### DIFF
--- a/lib/3scale/backend/async_redis/protocol/extended_resp2.rb
+++ b/lib/3scale/backend/async_redis/protocol/extended_resp2.rb
@@ -13,7 +13,7 @@ module ThreeScale
 
           def initialize(db: nil, credentials: [])
             @db = db
-            @credentials = credentials
+            @credentials = credentials.reject{_1.to_s.strip.empty?}
           end
 
           def client(stream)


### PR DESCRIPTION
ACL Support works fine when both `user` and `password` are provided. But for backwards compatibility we need to properly send the credentials when the `user` is not specified.

In this scenario, our protocol needs to send the next command:

```
AUTH <password>
```

Check the [docs](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/).

This PR just adds a small fix to remove empty elements from the `credentials` array provided to the protocol.