### PR TITLE
THREESCALE-11205: Read sentinels credentials from the URI

### DIFF
--- a/test/unit/storage_async_test.rb
+++ b/test/unit/storage_async_test.rb
@@ -80,21 +80,6 @@ class StorageAsyncTest < Test::Unit::TestCase
                            conn)
   end
 
-  def test_sentinels_connection_array_hashes
-    config_obj = {
-      url: 'redis://master-group-name',
-      sentinels: [{ host: '127.0.0.1', port: 26_379 },
-                  {},
-                  { host: '127.0.0.1', port: 36_379 },
-                  nil]
-    }
-
-    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
-    assert_sentinel_config({ url: config_obj[:url],
-                           sentinels: config_obj[:sentinels].compact.reject(&:empty?) },
-                           conn)
-  end
-
   def test_sentinels_malformed_url
     config_obj = {
       url: 'redis://master-group-name',
@@ -114,24 +99,6 @@ class StorageAsyncTest < Test::Unit::TestCase
     conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
     assert_sentinel_config({ url: config_obj[:url],
                            sentinels: [{ host: '127.0.0.1', port: 26_379 }] },
-                           conn)
-  end
-
-  def test_sentinels_array_hashes_default_port
-    default_sentinel_port = Storage::Helpers.singleton_class.const_get(:DEFAULT_SENTINEL_PORT)
-    config_obj = {
-      url: 'redis://master-group-name',
-      sentinels: [{ host: '127.0.0.1' }, { host: '192.168.1.1' },
-                  { host: '192.168.1.2', port: nil },
-                  { host: '127.0.0.1', port: 36379 }]
-    }
-
-    conn = StorageAsync::Client.send :new, Storage::Helpers.config_with(config_obj)
-    assert_sentinel_config({ url: config_obj[:url],
-                           sentinels: [{ host: '127.0.0.1', port: default_sentinel_port },
-                                       { host: '192.168.1.1', port: default_sentinel_port },
-                                       { host: '192.168.1.2', port: default_sentinel_port },
-                                       { host: '127.0.0.1', port: 36379 }] },
                            conn)
   end
 
@@ -192,7 +159,7 @@ class StorageAsyncTest < Test::Unit::TestCase
   end
 
   def test_sentinels_empty
-    [nil, '', ' ', [], [nil], [''], [' '], [{}]].each do |sentinels_val|
+    [nil, '', ' ', [], [nil], [''], [' ']].each do |sentinels_val|
       config_obj = {
         url: 'redis://master-group-name',
         sentinels: sentinels_val


### PR DESCRIPTION
**What this PR does / why we need it**:

Last changes to support TLS for Redis caused a regression that broke one scenario: reading the sentinels credentials from the URL.

Now providing a sentinel URL like this should be accepted:

```
rediss://user:password@localhost:56380 
```

**Which issue(s) this PR fixes** 

https://issues.redhat.com/browse/THREESCALE-11205

**Verification steps** 

1. Don't set `CONFIG_REDIS_SENTINEL_USERNAME` nor `CONFIG_REDIS_SENTINEL_PASSWORD`.
2. Include credentials in `CONFIG_REDIS_SENTINEL_HOSTS`:
```
CONFIG_REDIS_SENTINEL_HOSTS=rediss://username:password@localhost:56380,rediss://localhost:56381,rediss://localhost:56382`
```
3. It all should work fine
