### PR TITLE
THREESCALE-10826: Add support for unix sockets in async mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ commands:
             cp -r script/config/examples/tls/sentinel1 ./sentinel1_tls
             cp -r script/config/examples/tls/sentinel2 ./sentinel2_tls
             cp -r script/config/examples/tls/sentinel3 ./sentinel3_tls
+            mkdir -m 1777 ./run
       - run:
           name: Start services
           command: |
@@ -119,7 +120,13 @@ workflows:
       - test_single:
           requires:
             - install_dependencies
+      - test_single_unix:
+          requires:
+            - install_dependencies
       - test_sentinels:
+          requires:
+            - install_dependencies
+      - test_acl_unix:
           requires:
             - install_dependencies
       - test_tls:
@@ -161,6 +168,18 @@ jobs:
       - start_services:
           services: redis-master
       - run_tests
+  test_single_unix:
+    executor:
+      name: ubuntu_vm
+    working_directory: ~/project
+    environment:
+      CONFIG_QUEUES_MASTER_NAME: unix://run/redis.sock
+      CONFIG_REDIS_PROXY: unix://run/redis.sock
+    steps:
+      - *attach-to-workspace
+      - start_services:
+          services: redis-master
+      - run_tests
   test_sentinels:
     executor:
       name: ubuntu_vm
@@ -174,6 +193,22 @@ jobs:
       - *attach-to-workspace
       - start_services:
           services: redis-master redis-replica1 redis-replica2 redis-sentinel1 redis-sentinel2 redis-sentinel3
+      - run_tests
+  test_acl_unix:
+    executor:
+      name: ubuntu_vm
+    working_directory: ~/project
+    environment:
+      CONFIG_QUEUES_MASTER_NAME: unix://run/redis.sock
+      CONFIG_QUEUES_USERNAME: porta
+      CONFIG_QUEUES_PASSWORD: sup3rS3cre1!
+      CONFIG_REDIS_PROXY: unix://run/redis.sock
+      CONFIG_REDIS_USERNAME: porta
+      CONFIG_REDIS_PASSWORD: sup3rS3cre1!
+    steps:
+      - *attach-to-workspace
+      - start_services:
+          services: tls-redis-master
       - run_tests
   test_tls:
     executor:

--- a/lib/3scale/backend/async_redis/endpoint_helpers.rb
+++ b/lib/3scale/backend/async_redis/endpoint_helpers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'async/io'
+require 'async/io/unix_endpoint'
 
 module ThreeScale
   module Backend
@@ -14,18 +15,35 @@ module ThreeScale
 
           # @param host [String]
           # @param port [Integer]
+          # @param path [String]
+          # @param ssl [Boolean]
           # @param ssl_params [Hash]
           # @return [Async::IO::Endpoint::Generic]
-          def prepare_endpoint(host, port, ssl = false, ssl_params = nil)
+          def prepare_endpoint(**kwargs)
+            host_present?(kwargs[:host]) ? prepare_tcp_endpoint(**kwargs) : prepare_unix_endpoint(**kwargs)
+          end
+
+          private
+
+          def prepare_tcp_endpoint(host: nil, port: nil, ssl: false, ssl_params: nil)
             tcp_endpoint = Async::IO::Endpoint.tcp(host, port)
 
-            if ssl
-              ssl_context = OpenSSL::SSL::SSLContext.new
-              ssl_context.set_params(format_ssl_params(ssl_params)) if ssl_params
-              return Async::IO::SSLEndpoint.new(tcp_endpoint, ssl_context: ssl_context)
-            end
+            return prepare_ssl_endpoint(endpoint: tcp_endpoint, ssl_params: ssl_params) if ssl
 
             tcp_endpoint
+          end
+
+          def prepare_unix_endpoint(path: '', ssl: false, ssl_params: nil)
+            unix_endpoint = Async::IO::Endpoint.unix(path, Socket::PF_UNIX)
+            return unix_endpoint unless ssl
+
+            prepare_ssl_endpoint(endpoint: unix_endpoint, ssl_params: ssl_params)
+          end
+
+          def prepare_ssl_endpoint(endpoint: nil, ssl_params: nil)
+            ssl_context = OpenSSL::SSL::SSLContext.new
+            ssl_context.set_params(format_ssl_params(ssl_params)) if ssl_params
+            Async::IO::SSLEndpoint.new(endpoint, ssl_context: ssl_context)
           end
 
           def format_ssl_params(ssl_params)
@@ -38,6 +56,10 @@ module ThreeScale
             updated_ssl_params[:key] = OpenSSL::PKey.read(File.read(key))
 
             updated_ssl_params
+          end
+
+          def host_present?(host)
+            !host.to_s.strip.empty?
           end
         end
       end

--- a/lib/3scale/backend/async_redis/sentinels_client_acl_tls.rb
+++ b/lib/3scale/backend/async_redis/sentinels_client_acl_tls.rb
@@ -10,7 +10,7 @@ module ThreeScale
         def initialize(uri, protocol = Async::Redis::Protocol::RESP2, config, **options)
           @master_name = uri.host
           @sentinel_endpoints = config[:sentinels].map do |sentinel|
-            EndpointHelpers.prepare_endpoint(sentinel[:host], sentinel[:port], config[:ssl], config[:ssl_params])
+            EndpointHelpers.prepare_endpoint(host: sentinel[:host], port: sentinel[:port], ssl: config[:ssl], ssl_params: config[:ssl_params])
           end
           @role = config[:role] || :master
 
@@ -32,7 +32,7 @@ module ThreeScale
               next
             end
 
-            return EndpointHelpers.prepare_endpoint(address[0], address[1], @config[:ssl], @config[:ssl_params]) if address
+            return EndpointHelpers.prepare_endpoint(host: address[0], port: address[1], ssl:@config[:ssl], ssl_params: @config[:ssl_params]) if address
           end
 
           nil
@@ -52,7 +52,7 @@ module ThreeScale
             next if slaves.empty?
 
             slave = select_slave(slaves)
-            return EndpointHelpers.prepare_endpoint(slave['ip'], slave['port'], @config[:ssl], @config[:ssl_params])
+            return EndpointHelpers.prepare_endpoint(host: slave['ip'], port: slave['port'], ssl: @config[:ssl], ssl_params: @config[:ssl_params])
           end
 
           nil

--- a/script/config/examples/tls/master.conf
+++ b/script/config/examples/tls/master.conf
@@ -1,4 +1,6 @@
 port 0
+unixsocket /var/run/redis/redis.sock
+unixsocketperm 777
 tls-port 46380
 tls-cert-file /etc/redis.crt
 tls-key-file /etc/redis.key

--- a/script/config/podman-compose.yml
+++ b/script/config/podman-compose.yml
@@ -4,7 +4,9 @@ services:
     image: redis:6.2-alpine
     container_name: redis-master
     network_mode: host
-    command: [ redis-server, --port, "6379" ]
+    volumes:
+      - ./run:/var/run/redis:z
+    command: [ redis-server, --port, "6379", --unixsocket, "/var/run/redis/redis.sock", --unixsocketperm, "777" ]
 
   redis-replica1:
     image: redis:6.2-alpine
@@ -47,6 +49,7 @@ services:
     container_name: tls-redis-master
     network_mode: host
     volumes:
+      - ./run:/var/run/redis:z
       - ./master.conf:/etc/redis.conf:z
       - ./circleci.crt:/etc/redis.crt:z
       - ./circleci.key:/etc/redis.key:z


### PR DESCRIPTION
Connection to Redis through unix sockets is not supported in async mode. This PR adds the logic to implement it. Basically, before the PR the code only followed one path to connect using a TCP socket, now the code is split into two paths, one for TCP and one for Unix.

This is part of https://issues.redhat.com/browse/THREESCALE-10826

**How to verify**

1. Launch a redis container listening in the unix socket:
```
podman run --name redis-unix -v /path/to/your/run:/var/run/:z redis:6.2-alpine redis-server --unixsocket /var/run/redis.sock --unixsocketperm 777 --port 0
```
2. Set `CONFIG_QUEUES_MASTER_NAME` and `CONFIG_REDIS_PROXY` to `unix:///path/to/your/run/redis.sock`
3. Both listener and worker should work as usual

Additionally, ACL credentials can be provided through the corresponding environment variables, when the server is authenticated. Sentinels and TLS connections cannot be established through unix sockets, though.