### PR TITLE
THREESCALE-11528: Redis connection re-establishment in async mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       traces (>= 0.8.0)
     async-http-cache (0.4.3)
       async-http (~> 0.56)
-    async-io (1.34.3)
+    async-io (1.43.2)
       async
     async-pool (0.3.12)
       async (>= 1.25)
@@ -75,9 +75,10 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.1)
     connection_pool (2.4.1)
-    console (1.23.2)
+    console (1.29.2)
       fiber-annotation
-      fiber-local
+      fiber-local (~> 1.1)
+      json
     daemons (1.2.4)
     diff-lcs (1.5.1)
     docile (1.1.5)
@@ -98,7 +99,9 @@ GEM
       protocol-rack (~> 0.1)
       samovar (~> 2.1)
     fiber-annotation (0.2.0)
-    fiber-local (1.0.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.0)
     gli (2.16.1)
     google-protobuf (4.28.2)
       bigdecimal
@@ -134,7 +137,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
-    nio4r (2.5.9)
+    nio4r (2.7.4)
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+ENV['BACKEND_COMPONENT'] = 'listener'
+
 require_relative 'lib/3scale/bundler_shim'
 require '3scale/backend/rack'
 

--- a/lib/3scale/backend.rb
+++ b/lib/3scale/backend.rb
@@ -16,6 +16,7 @@ require 'yaml'
 require 'digest/md5'
 
 # Require here the classes needed for configuring Backend
+require '3scale/backend/component'
 require '3scale/backend/environment'
 require '3scale/backend/version'
 require '3scale/backend/constants'

--- a/lib/3scale/backend/component.rb
+++ b/lib/3scale/backend/component.rb
@@ -1,0 +1,17 @@
+module ThreeScale
+  module Backend
+    class << self
+      def component
+        @component ||= ENV['BACKEND_COMPONENT'] || 'worker'
+      end
+
+      def listener?
+        component == 'listener'
+      end
+
+      def worker?
+        component == 'worker'
+      end
+    end
+  end
+end

--- a/lib/3scale/backend/errors.rb
+++ b/lib/3scale/backend/errors.rb
@@ -1,3 +1,6 @@
+require 'redis/errors'
+require 'redis_client'
+
 module ThreeScale
   module Backend
     class Error < RuntimeError
@@ -297,5 +300,22 @@ module ThreeScale
         super 'End-users are no longer supported, do not specify the user_id parameter'.freeze
       end
     end
+
+    class PipelineSharedBetweenFibers < Error
+      def initialize
+        super 'several fibers are modifying the same Pipeline'
+      end
+    end
+
+    class BrokenPipeline < Error
+      def initialize
+        super 'Redis pipeline is broken'
+      end
+    end
+
+    CONNECTION_ERRORS = [
+      Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ECONNABORTED,
+      Errno::EPIPE, Errno::EAGAIN, BrokenPipeline, EOFError, OpenSSL::SSL::SSLError
+    ]
   end
 end

--- a/lib/3scale/backend/storage_async.rb
+++ b/lib/3scale/backend/storage_async.rb
@@ -1,3 +1,3 @@
 require '3scale/backend/storage_async/methods'
-require '3scale/backend/storage_async/client'
 require '3scale/backend/storage_async/pipeline'
+require '3scale/backend/storage_async/client'

--- a/spec/unit/queue_storage_spec.rb
+++ b/spec/unit/queue_storage_spec.rb
@@ -44,7 +44,7 @@ module ThreeScale
 
       def is_sentinel?(connection)
         if ThreeScale::Backend.configuration.redis.async
-          connector = connection.instance_variable_get(:@inner).instance_variable_get(:@redis_async)
+          connector = connection.instance_variable_get(:@inner).connect
           connector.instance_of?(ThreeScale::Backend::AsyncRedis::SentinelsClientACLTLS)
         else
           connector = connection.instance_variable_get(:@inner)

--- a/spec/unit/storage_async/pipeline_spec.rb
+++ b/spec/unit/storage_async/pipeline_spec.rb
@@ -6,7 +6,7 @@ module ThreeScale
       describe Pipeline do
         describe '.run' do
           let(:storage) {ThreeScale::Backend::StorageAsync::Client.instance(true)}
-          let(:async_client) { storage.instance_variable_get(:@inner).instance_variable_get(:@redis_async) }
+          let(:async_client) { storage.instance_variable_get(:@inner).connect }
 
           subject { Pipeline.new }
 
@@ -36,7 +36,7 @@ module ThreeScale
               pipeline = nil
               Fiber.new { pipeline = Pipeline.new }.resume
               expect { Fiber.new { pipeline.call('GET', 'some_key') }.resume }
-                  .to raise_error Pipeline::PipelineSharedBetweenFibers
+                  .to raise_error PipelineSharedBetweenFibers
             end
           end
         end

--- a/test/unit/storage_async_test.rb
+++ b/test/unit/storage_async_test.rb
@@ -5,6 +5,10 @@ require '3scale/backend/storage_async'
 class StorageAsyncTest < Test::Unit::TestCase
   include TestHelpers::Certificates
 
+  def setup
+    omit_unless(configuration.redis.async, 'skipping an async test as sync mode is enabled')
+  end
+
   def test_basic_operations
     storage = StorageAsync::Client.instance(true)
     storage.del('foo')
@@ -307,7 +311,7 @@ class StorageAsyncTest < Test::Unit::TestCase
   end
 
   def assert_client_config(conf, conn, test_cert_type = nil)
-    client = conn.instance_variable_get(:@inner).instance_variable_get(:@redis_async)
+    client = conn.instance_variable_get(:@inner).connect
 
     if conf[:url].to_s.strip.empty?
       path = conf[:path]
@@ -326,7 +330,7 @@ class StorageAsyncTest < Test::Unit::TestCase
   end
 
   def assert_sentinel_config(conf, conn, test_cert_type = nil)
-    client = conn.instance_variable_get(:@inner).instance_variable_get(:@redis_async)
+    client = conn.instance_variable_get(:@inner).connect
     uri = URI(conf[:url] || '')
     name = uri.host
     role = conf[:role] || :master

--- a/test/unit/storage_sync_test.rb
+++ b/test/unit/storage_sync_test.rb
@@ -2,6 +2,11 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 require '3scale/backend/storage_sync'
 
 class StorageSyncTest < Test::Unit::TestCase
+
+  def setup
+    omit_if(configuration.redis.async, 'skipping a sync test as async mode is enabled')
+  end
+
   def test_basic_operations
     storage = StorageSync.instance(true)
     storage.del('foo')


### PR DESCRIPTION
This is a proposal on how to implement reconnection to Redis when the link is broken. The idea is taken from redis-client gem ([code](https://github.com/redis-rb/redis-client/blob/7a3e3627802060af38b98ca045032cd46e1313cf/lib/redis_client.rb#L691)). Before every request to Redis, `ensure_connected` is called, this way:

- When a request fails because a broken link, that doesn't affect the next requests.
- Next requests will also fail while the link is broken.
- As soon as the link is restored, the next request will get a valid connection and will work.

This PR also implements an implementation for the `reconnect_attempts` option:
https://github.com/3scale/apisonator/blob/e79bef023dc250e7a916a4afe93d6fa0c34599e6/lib/3scale/backend/storage_helpers.rb#L53

Which was being ignored in async mode. It just retries to connect to Redis once (by default) before raising the exception.

In the case the exception is raised:

- The listener just returns a 403 and keep going. Requests will work again as soon as the link is restored
- The worker doesn't crash anymore, it waits for 5 seconds and try again, forever, until the link is restored.

**Jira:**

https://issues.redhat.com/browse/THREESCALE-11528

**Notes:**

This PR only fixes the async mode. Sync mode uses `redis` and `redis-client` gems which already handle connection loss.