### PR TITLE
Fix tests for recent openssl versions

### DIFF
--- a/test/test_helpers/certificates.rb
+++ b/test/test_helpers/certificates.rb
@@ -28,31 +28,48 @@ module TestHelpers
       end
     end
 
-    def create_cert(key = create_key(:rsa))
-      public_key = get_public_key(key)
+    def create_ca(key = create_key(:rsa))
+      root_ca = OpenSSL::X509::Certificate.new
+      root_ca.version = 2 # cf. RFC 5280 - to make it a "v3" certificate
+      root_ca.serial = 0x1
+      root_ca.subject = OpenSSL::X509::Name.parse "/DC=test/DC=backend/CN=TestCA"
+      root_ca.issuer = root_ca.subject # root CA's are "self-signed"
+      root_ca.public_key = get_public_key(key)
+      root_ca.not_before = Time.now
+      root_ca.not_after = root_ca.not_before + 2 * 365 * 24 * 60 * 60 # 2 years validity
 
-      subject = "/C=BE/O=Test/OU=Test/CN=Test"
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = root_ca
+      ef.issuer_certificate = root_ca
 
+      root_ca.add_extension(ef.create_extension("basicConstraints","CA:TRUE", true))
+      root_ca.add_extension(ef.create_extension("keyUsage","keyCertSign, cRLSign", true))
+      root_ca.add_extension(ef.create_extension("subjectKeyIdentifier","hash", false))
+      root_ca.add_extension(ef.create_extension("authorityKeyIdentifier","keyid:always", false))
+
+      root_ca.sign(key, OpenSSL::Digest.new('SHA512'))
+
+      root_ca
+    end
+
+    def create_cert(key = create_key(:rsa), root_ca, root_key)
       cert = OpenSSL::X509::Certificate.new
-      cert.subject = cert.issuer = OpenSSL::X509::Name.parse(subject)
-      cert.not_before = Time.now
-      cert.not_after = Time.now + 365 * 24 * 60 * 60
-      cert.public_key = public_key
-      cert.serial = 0x0
       cert.version = 2
+      cert.serial = 0x2
+      cert.subject = OpenSSL::X509::Name.parse "/DC=test/DC=backend/CN=TestCert"
+      cert.issuer = root_ca.subject # root CA is the issuer
+      cert.public_key = get_public_key(key)
+      cert.not_before = Time.now
+      cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60 # 1 year validity
 
       ef = OpenSSL::X509::ExtensionFactory.new
       ef.subject_certificate = cert
-      ef.issuer_certificate = cert
-      cert.extensions = [
-        ef.create_extension("basicConstraints","CA:TRUE", true),
-        ef.create_extension("subjectKeyIdentifier", "hash"),
-      # ef.create_extension("keyUsage", "cRLSign,keyCertSign", true),
-      ]
-      cert.add_extension ef.create_extension("authorityKeyIdentifier",
-                                             "keyid:always,issuer:always")
+      ef.issuer_certificate = root_ca
 
-      cert.sign key, (key.is_a?(OpenSSL::PKey::DSA) ? OpenSSL::Digest::SHA1.new : OpenSSL::Digest::SHA512.new)
+      cert.add_extension(ef.create_extension("keyUsage","digitalSignature", true))
+      cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash", false))
+      cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
+
       cert
     end
 


### PR DESCRIPTION
After upgrading to Fedora 41, my openssl lib was updated and tests started to fail locally.

In my tests I found it was because using a DSA key and a SHA1 digest algorithm altogether fails with a `invalid digest` error. If it try to use SHA512 as a digest algorithm for DSA, then I receive a `ca md too weak` error. However, the combination DSA + SHA256 works fine for me locally.

I just refactored the code and copied the code to generate the fake certs from the [official docs](https://docs.ruby-lang.org/en/3.1/OpenSSL/X509/Certificate.html#class-OpenSSL::X509::Certificate-label-Creating+a+root+CA+certificate+and+an+end-entity+certificate), which use SHA256.