### PR TITLE
THREESCALE-11574: Filter out invalid 'log' parameter

### DIFF
--- a/test/integration/authrep/response_codes_test.rb
+++ b/test/integration/authrep/response_codes_test.rb
@@ -61,5 +61,36 @@ class AuthRepResponseCodesTest < Test::Unit::TestCase
     transaction = enqueued_job['args'][1]['0']
     assert_nil transaction['log']['request']
     assert_nil transaction['log']['response']
+    assert_equal '200', transaction['log']['code']
+  end
+
+  test_authrep "ignore log param that doesn't contain code" do |e|
+    get e, {
+      provider_key: @provider_key,
+      app_id: @application.id,
+      usage: { 'hits' => 1 },
+      log: { invalid: 'whatever' }
+    }
+
+    enqueued_job = Resque.list_range(:priority)
+
+    # transactions is the second arg ([1]), we only sent one (['0'])
+    transaction = enqueued_job['args'][1]['0']
+    assert_nil transaction['log']
+  end
+
+  test_authrep "ignore invalid log param" do |e|
+    get e, {
+      provider_key: @provider_key,
+      app_id: @application.id,
+      usage: { 'hits' => 1 },
+      log: 'some-string'
+    }
+
+    enqueued_job = Resque.list_range(:priority)
+
+    # transactions is the second arg ([1]), we only sent one (['0'])
+    transaction = enqueued_job['args'][1]['0']
+    assert_nil transaction['log']
   end
 end

--- a/test/integration/authrep/response_codes_test.rb
+++ b/test/integration/authrep/response_codes_test.rb
@@ -80,17 +80,19 @@ class AuthRepResponseCodesTest < Test::Unit::TestCase
   end
 
   test_authrep "ignore invalid log param" do |e|
-    get e, {
-      provider_key: @provider_key,
-      app_id: @application.id,
-      usage: { 'hits' => 1 },
-      log: 'some-string'
-    }
-
-    enqueued_job = Resque.list_range(:priority)
-
-    # transactions is the second arg ([1]), we only sent one (['0'])
-    transaction = enqueued_job['args'][1]['0']
-    assert_nil transaction['log']
+    ["some-string", ["array-element"], "", nil].each do |log_value|
+      get e, {
+        provider_key: @provider_key,
+        app_id: @application.id,
+        usage: { 'hits' => 1 },
+        log: log_value
+      }
+  
+      enqueued_job = Resque.list_range(:priority)
+  
+      # transactions is the second arg ([1]), we only sent one (['0'])
+      transaction = enqueued_job['args'][1]['0']
+      assert_nil transaction['log']
+    end
   end
 end


### PR DESCRIPTION
Fixes [THREESCALE-11574](https://issues.redhat.com/browse/THREESCALE-11574)

This was giving a `500` when sending something like `log=somestring` in the params.