### PR TITLE
[CVE] Bump Openssl version from 3.2.0 to 3.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    openssl (3.2.0)
+    openssl (3.2.2)
     opentelemetry-api (1.4.0)
     opentelemetry-common (0.21.0)
       opentelemetry-api (~> 1.0)


### PR DESCRIPTION
[THREESCALE-11083: CVE-2024-4741 3scale-amp-backend-container: openssl: Use After Free with SSL_free_buffers [3amp-2.14]](https://issues.redhat.com/browse/THREESCALE-11083)