### PR TITLE
prefer `branch` over `ref`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'rspec_api_documentation', '~> 6.0', github: '3scale/rspec_api_documentation', ref: 'fix-nil-rewind'
+  gem 'rspec_api_documentation', '~> 6.0', github: '3scale/rspec_api_documentation', branch: 'fix-nil-rewind'
 end
 
 # Default server by platform

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/3scale/rspec_api_documentation.git
   revision: 7f2190a9236c7827f8606245b92d1522df392d31
-  ref: fix-nil-rewind
+  branch: fix-nil-rewind
   specs:
     rspec_api_documentation (6.1.0)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
`ref` seems not to be supported by cachi2 currently (our tool of choice for prefetching dependencies in the product build)

Hopefully this change doesn't affect anything else 