### PR TITLE
THREESCALE-11536: remove `rspec_api_documentation`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'rspec_api_documentation', '~> 6.0', github: '3scale/rspec_api_documentation', branch: 'fix-nil-rewind'
+  gem 'activesupport', '~> 7.1.3.3'
 end
 
 # Default server by platform

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/3scale/rspec_api_documentation.git
-  revision: 7f2190a9236c7827f8606245b92d1522df392d31
-  branch: fix-nil-rewind
-  specs:
-    rspec_api_documentation (6.1.0)
-      activesupport (>= 3.0.0)
-      mustache (~> 1.0, >= 0.99.4)
-      rspec (~> 3.0)
-
-GIT
   remote: https://github.com/3scale/source2swagger
   revision: 9a787007577fc58b5822b55720e977cc063057fd
   branch: backend
@@ -24,7 +14,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.3)
+    activesupport (7.1.3.4)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -114,7 +104,7 @@ GEM
       google-protobuf (>= 3.18, < 5.a)
     hiredis-client (0.23.0)
       redis-client (= 0.23.0)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     license_finder (7.1.0)
@@ -130,12 +120,11 @@ GEM
     metaclass (0.0.4)
     method_source (1.1.0)
     mini_portile2 (2.8.6)
-    minitest (5.25.2)
+    minitest (5.25.4)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     mono_logger (1.1.2)
     multi_json (1.15.0)
-    mustache (1.1.1)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.3.0)
@@ -311,6 +300,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 7.1.3.3)
   apisonator!
   async (~> 1.31)
   async-pool (~> 0.3.12)
@@ -346,7 +336,6 @@ DEPENDENCIES
   resque_spec (~> 0.17.0)
   resque_unit (~> 0.4.4)
   rspec (~> 3.7.0)
-  rspec_api_documentation (~> 6.0)!
   sinatra (~> 4.1.0)
   sinatra-contrib (~> 4.1.0)
   source2swagger!

--- a/Rakefile
+++ b/Rakefile
@@ -127,12 +127,6 @@ if Environment.testable?
 
   end
 
-  desc 'Generate API request documentation from API specs'
-  RSpec::Core::RakeTask.new('docs:generate') do |t|
-    t.pattern = 'spec/acceptance/**/*_spec.rb'
-    t.rspec_opts = ['--format RspecApiDocumentation::ApiFormatter']
-  end
-
   desc 'Tag and push the current version'
   task :release => ['release:tag', 'release:push']
 

--- a/docs/specs/backend_internal.yaml
+++ b/docs/specs/backend_internal.yaml
@@ -1,0 +1,939 @@
+openapi: 3.0.1
+info:
+  title: 3scale Backend Internal API
+  version: 1.0.0
+servers:
+- url: http://localhost:3001/internal
+paths:
+  /services/{service_id}/alert_limits/:
+    get:
+      tags:
+      - Alert limits
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Getting alert limits
+    post:
+      tags:
+      - Alert limits
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlertLimit'
+        required: true
+      responses:
+        "201":
+          description: Add an alert limit
+  /services/{service_id}/alert_limits/{value}:
+    delete:
+      tags:
+      - Alert limits
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: value
+        in: path
+        description: Limit value
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Delete an alert limit
+  /services/{service_id}/applications/{app_id}/keys/:
+    get:
+      tags:
+      - Application keys
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: app_id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Getting application keys
+    post:
+      tags:
+      - Application keys
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: app_id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Application key value
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationKey'
+        required: true
+      responses:
+        "201":
+          description: Add an application key
+  /services/{service_id}/applications/{app_id}/keys/{value}:
+    delete:
+      tags:
+      - Application keys
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: app_id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      - name: value
+        in: path
+        description: Application key value
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Delete an application key
+  /services/{service_id}/applications/{app_id}/referrer_filters:
+    get:
+      tags:
+      - Application Referrer Filters
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: app_id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Getting referrer filters
+    post:
+      tags:
+      - Application Referrer Filters
+      parameters:
+      - name: service_id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: app_id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReferrerFilter'
+        required: true
+      responses:
+        "201":
+          description: Create a referrer filter
+        "400":
+          description: Try updating a referrer filter with invalid data
+        "404":
+          description: Try updating a referrer filter with invalid application id
+  /services/{service_id}/applications/{app_id}/referrer_filters/{filter}:
+    delete:
+      tags:
+      - Application Referrer Filters
+      parameters:
+      - name: filter
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: app_id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Trying to delete a filter
+  /services/{service_id}/applications/{id}:
+    get:
+      tags:
+      - Applications
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Get Application by ID
+        "404":
+          description: Try to get an Application by non-existent ID
+    put:
+      tags:
+      - Applications
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Application'
+        required: true
+      responses:
+        "200":
+          description: updating the application
+        "400":
+          description: trying to update the application
+    post:
+      tags:
+      - Applications
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Application'
+        required: true
+      responses:
+        "201":
+          description: Create an Application
+        "400":
+          description: Trying to create the application
+    delete:
+      tags:
+      - Applications
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Deleting an application
+  /services/{service_id}/applications/key/{user_key}:
+    get:
+      tags:
+      - Applications
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: user_key
+        in: path
+        description: User key for this Application
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Get existing ID of Application with service and key
+        "404":
+          description: Try to get an Application ID from a non-existing key
+    delete:
+      tags:
+      - Applications
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: user_key
+        in: path
+        description: User key for this Application
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Delete an Application's user key
+  /services/{service_id}/applications/{id}/key/{user_key}:
+    put:
+      tags:
+      - Applications
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      - name: user_key
+        in: path
+        description: User key for this Application
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Change the key for an Application
+  /services/{service_id}/errors/:
+    get:
+      tags:
+      - Errors
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Get errors by service ID
+        "400":
+          description: Try with negative per_page value
+        "404":
+          description: Try with invalid service ID
+    post:
+      tags:
+      - Errors
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Errors
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Errors'
+        required: false
+      responses:
+        "201":
+          description: Save errors
+        "400":
+          description: Try without specifying errors
+        "404":
+          description: Try to save errors
+    delete:
+      tags:
+      - Errors
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Delete all errors
+        "404":
+          description: Try with invalid service ID
+  /events/:
+    get:
+      tags:
+      - Events
+      responses:
+        "200":
+          description: Getting events
+    post:
+      tags:
+      - Events
+      requestBody:
+        description: Events
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Events'
+        required: false
+      responses:
+        "201":
+          description: Save events
+        "400":
+          description: Try to save events
+  /events/{id}:
+    delete:
+      tags:
+      - Events
+      parameters:
+      - name: id
+        in: path
+        description: Event ID
+        required: true
+        schema:
+          type: integer
+      responses:
+        "200":
+          description: Delete Event by ID
+  /check.json:
+    get:
+      tags:
+      - Internal API
+      responses:
+        "200":
+          description: Check internal API live status
+  /status:
+    get:
+      tags:
+      - Internal API
+      responses:
+        "200":
+          description: Get Backend's version
+  /services/{service_id}/metrics/{id}:
+    get:
+      tags:
+      - Metrics
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Metric ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Get Metric by ID
+        "404":
+          description: Try to get a Metric by non-existent ID
+    put:
+      tags:
+      - Metrics
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Metric ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Metric attributes
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlertLimit'
+        required: true
+      responses:
+        "200":
+          description: Update Metric by ID
+    post:
+      tags:
+      - Metrics
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Metric ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Metric attributes
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Metric'
+        required: true
+      responses:
+        "201":
+          description: Create a Metric
+    delete:
+      tags:
+      - Metrics
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Metric ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Deleting a Metric
+  /service_tokens/{token}/{service_id}/:
+    head:
+      tags:
+      - Service Tokens
+      parameters:
+      - name: token
+        in: path
+        description: token
+        required: true
+        schema:
+          type: string
+      - name: service_id
+        in: path
+        description: service ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Check if the pair exists
+        "404":
+          description: Check if the pair exists
+  /service_tokens/{token}/{service_id}/provider_key:
+    get:
+      tags:
+      - Service Tokens
+      parameters:
+      - name: token
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: service_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Get the provider key
+        "404":
+          description: Try to get the provider key
+  /service_tokens/:
+    post:
+      tags:
+      - Service Tokens
+      requestBody:
+        description: Service Tokens
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceTokens'
+        required: true
+      responses:
+        "201":
+          description: "Create a (service_token, service_id) pair"
+        "400":
+          description: "Try to create a (service_token, service_id) without sending\
+            \ service_tokens"
+        "422":
+          description: "Try to create a (service_token, service_id) pair with null\
+            \ service_token"
+  /services/{id}:
+    get:
+      tags:
+      - Services
+      parameters:
+      - name: id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Get Service by ID
+        "404":
+          description: Try to get a Service by non-existent ID
+    put:
+      tags:
+      - Services
+      parameters:
+      - name: id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        description: Service attributes
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlertLimit'
+        required: true
+      responses:
+        "200":
+          description: Update Service by ID
+    delete:
+      tags:
+      - Services
+      parameters:
+      - name: id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Deleting a default service when it is the only one
+        "400":
+          description: Deleting a default service when there are more
+  /services/:
+    post:
+      tags:
+      - Services
+      requestBody:
+        description: Service attributes
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Service'
+        required: true
+      responses:
+        "201":
+          description: Create a Service
+        "400":
+          description: Try creating a Service without specifying the service parameter
+            in the body
+  /services/change_provider_key/{key}:
+    put:
+      tags:
+      - Services
+      parameters:
+      - name: key
+        in: path
+        description: Existing provider key
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: New provider key
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewKey'
+        required: true
+      responses:
+        "200":
+          description: Changing a provider key
+        "400":
+          description: Trying to change a provider key to empty
+  /services/{service_id}/stats:
+    delete:
+      tags:
+      - Stats
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Deleting stats
+        "404":
+          description: Deleting stats
+  /services/{service_id}/plans/{plan_id}/usagelimits/{metric_id}/{period}:
+    get:
+      tags:
+      - UsageLimits
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: plan_id
+        in: path
+        description: Plan ID
+        required: true
+        schema:
+          type: string
+      - name: metric_id
+        in: path
+        description: Metric ID
+        required: true
+        schema:
+          type: string
+      - name: period
+        in: path
+        description: Period
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Get UsageLimits
+    put:
+      tags:
+      - UsageLimits
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: plan_id
+        in: path
+        description: Plan ID
+        required: true
+        schema:
+          type: string
+      - name: metric_id
+        in: path
+        description: Metric ID
+        required: true
+        schema:
+          type: string
+      - name: period
+        in: path
+        description: Period
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: UsageLimit attributes
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsageLimit'
+        required: true
+      responses:
+        "200":
+          description: Update UsageLimits
+    delete:
+      tags:
+      - UsageLimits
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: plan_id
+        in: path
+        description: Plan ID
+        required: true
+        schema:
+          type: string
+      - name: metric_id
+        in: path
+        description: Metric ID
+        required: true
+        schema:
+          type: string
+      - name: period
+        in: path
+        description: Period
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Delete UsageLimits
+  /services/{service_id}/applications/{app_id}/utilization/:
+    get:
+      tags:
+      - Utilization
+      parameters:
+      - name: service_id
+        in: path
+        description: Service ID
+        required: true
+        schema:
+          type: string
+      - name: app_id
+        in: path
+        description: Application ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Get utilization
+        "404":
+          description: Try to get utilization
+components:
+  schemas:
+    AlertLimit:
+      required:
+      - value
+      type: object
+      properties:
+        value:
+          type: string
+    ApplicationKey:
+      required:
+      - value
+      type: object
+      properties:
+        value:
+          type: string
+    ReferrerFilter:
+      required:
+      - referrer_filter
+      type: object
+      properties:
+        referrer_filter:
+          type: string
+    Application:
+      type: object
+      properties:
+        service_id:
+          type: string
+        id:
+          type: string
+        plan_id:
+          type: string
+        plan_name:
+          type: string
+        state:
+          type: string
+        redirect_url:
+          type: string
+    Errors:
+      type: array
+      items:
+        type: string
+    Events:
+      type: array
+      items:
+        type: object
+        properties:
+          type:
+            type: string
+          object:
+            type: object
+            properties: {}
+    Metric:
+      type: object
+      properties:
+        service_id:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+    ServiceTokens:
+      type: object
+    Service:
+      type: object
+    NewKey:
+      type: object
+      properties:
+        new_key:
+          type: string
+    UsageLimit:
+      type: object
+      example:
+        usagelimit:
+          year: "1001"
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+security:
+  - basicAuth: []

--- a/spec/acceptance/api/internal/applications_api_spec.rb
+++ b/spec/acceptance/api/internal/applications_api_spec.rb
@@ -1,8 +1,9 @@
-resource 'Applications (prefix: /services/:service_id/applications)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
+describe 'Applications (prefix: /services/:service_id/applications)' do
 
   before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+
     ThreeScale::Backend::Application.delete('7575', '100') rescue nil
     ThreeScale::Backend::Application.save(service_id: '7575',
                                           id: '100',
@@ -12,136 +13,71 @@ resource 'Applications (prefix: /services/:service_id/applications)' do
                                           redirect_url: 'https://3scale.net')
   end
 
-  get '/services/:service_id/applications/:id' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Application ID', required: true
+  context '/services/:service_id/applications/:id' do
+    context 'GET' do
+      let(:service_id) { '7575' }
+      let(:id) { '100' }
+      let(:service_id_non_existent) { service_id.to_i.succ.to_s }
+      let(:id_non_existent) { id.to_i.succ.to_s }
 
-    let(:service_id) { '7575' }
-    let(:id) { '100' }
-    let(:service_id_non_existent) { service_id.to_i.succ.to_s }
-    let(:id_non_existent) { id.to_i.succ.to_s }
+      it 'Get Application by ID' do
+        get "/services/#{service_id}/applications/#{id}"
 
-    example_request 'Get Application by ID' do
-      expect(response_json['application']['id']).to eq id
-      expect(response_json['application']['service_id']).to eq service_id
-      expect(status).to eq 200
-    end
+        expect(response_json['application']['id']).to eq id
+        expect(response_json['application']['service_id']).to eq service_id
+        expect(status).to eq 200
+      end
 
-    example 'Try to get an Application by non-existent ID' do
-      do_request id: id_non_existent
-      expect(status).to eq 404
-      expect(response_json['error']).to match /application not found/i
-    end
+      it 'Try to get an Application by non-existent ID' do
+        get "/services/#{service_id}/applications/#{id_non_existent}"
 
-    example 'Try to get an Application by non-existent service ID' do
-      do_request service_id: service_id_non_existent
-      expect(status).to eq 404
-      expect(response_json['error']).to match /application not found/i
-    end
-  end
+        expect(status).to eq 404
+        expect(response_json['error']).to match /application not found/i
+      end
 
-  post '/services/:service_id/applications/:id' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Application ID', required: true
-    parameter :application, 'Application attributes', required: true
+      it 'Try to get an Application by non-existent service ID' do
+        get "/services/#{service_id_non_existent}/applications/#{id}"
 
-    let(:service_id) { '7575' }
-    let(:id) { '200' }
-    let(:plan_id) { '100' }
-    let(:plan_name) { 'some_plan' }
-    let(:state) { :active }
-    let(:redirect_url) { 'https://3scale.net' }
-    let(:application) do
-      {
-        service_id: service_id,
-        id: id,
-        plan_id: plan_id,
-        plan_name: plan_name,
-        state: state,
-        redirect_url: redirect_url
-      }
-    end
-    let(:raw_post){ params.to_json }
-
-    example_request 'Create an Application' do
-      expect(status).to eq 201
-      expect(response_json['status']).to eq 'created'
-
-      app = ThreeScale::Backend::Application.load(service_id, id)
-      expect(app.to_hash).to eq application
-    end
-
-    example 'Create an Application with extra params that should be ignored' do
-      application_params = application.merge(some_param: 'some_val')
-      do_request application: application_params
-      expect(status).to eq 201
-      expect(response_json['status']).to eq 'created'
-
-      app = ThreeScale::Backend::Application.load(service_id, id)
-      expect(app).not_to be_nil
-      expect(app).not_to respond_to :some_param
-      # The returned data should not contain *some_param* attribute
-      expect(app.to_hash).to eq application
-    end
-
-    context 'with an application that has no state' do
-      let (:state) { nil }
-
-      example_request 'Trying to create the application' do
-        expect(status).to eq 400
-        expect(response_json['status']).to eq 'bad_request'
-        expect(response_json['error']).to match /has no state/i
+        expect(status).to eq 404
+        expect(response_json['error']).to match /application not found/i
       end
     end
-    context 'with a disabled service' do
-      let (:service_id) { '6666' }
 
-      example 'Trying to create/update the application' do
-        ThreeScale::Backend::Service.save! id: service_id, provider_key: 'bar', state: :suspended
-        do_request
+    context 'POST' do
+      let(:service_id) { '7575' }
+      let(:id) { '200' }
+      let(:plan_id) { '100' }
+      let(:plan_name) { 'some_plan' }
+      let(:state) { :active }
+      let(:redirect_url) { 'https://3scale.net' }
+      let(:application) do
+        {
+          service_id: service_id,
+          id: id,
+          plan_id: plan_id,
+          plan_name: plan_name,
+          state: state,
+          redirect_url: redirect_url
+        }
+      end
+
+      it 'Create an Application' do
+        post "/services/#{service_id}/applications/#{id}", { application: }.to_json
+
         expect(status).to eq 201
         expect(response_json['status']).to eq 'created'
-      end
-    end
-  end
-
-  put '/services/:service_id/applications/:id' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Application ID', required: true
-    parameter :application, 'Application attributes', required: true
-
-    let(:service_id) { '7575' }
-    let(:id) { '100' }
-    let(:plan_id) { '101' }
-    let(:plan_name) { 'some_other_plan' }
-    let(:state) { :active }
-    let(:redirect_url) { 'https://3scale.net' }
-    let(:application) do
-      {
-        service_id: service_id,
-        id: id,
-        plan_id: plan_id,
-        plan_name: plan_name,
-        state: state,
-        redirect_url: redirect_url
-      }
-    end
-    let(:raw_post){ params.to_json }
-
-    context 'with an application that exists' do
-      example_request 'updating the application' do
-        expect(status).to eq 200
-        expect(response_json['status']).to eq 'modified'
 
         app = ThreeScale::Backend::Application.load(service_id, id)
         expect(app.to_hash).to eq application
       end
 
-      example 'updating the application with extra params that should be ignored' do
-        application_param = application.merge(some_param: 'some_val')
-        do_request application: application_param
-        expect(status).to eq 200
-        expect(response_json['status']).to eq 'modified'
+      it 'Create an Application with extra params that should be ignored' do
+        application_params = application.merge(some_param: 'some_val')
+
+        post "/services/#{service_id}/applications/#{id}", { application: application_params }.to_json
+
+        expect(status).to eq 201
+        expect(response_json['status']).to eq 'created'
 
         app = ThreeScale::Backend::Application.load(service_id, id)
         expect(app).not_to be_nil
@@ -149,127 +85,203 @@ resource 'Applications (prefix: /services/:service_id/applications)' do
         # The returned data should not contain *some_param* attribute
         expect(app.to_hash).to eq application
       end
+
+      context 'with an application that has no state' do
+        let (:state) { nil }
+
+        it 'Trying to create the application' do
+          post "/services/#{service_id}/applications/#{id}", { application: }.to_json
+
+          expect(status).to eq 400
+          expect(response_json['status']).to eq 'bad_request'
+          expect(response_json['error']).to match /has no state/i
+        end
+      end
+
+      context 'with a disabled service' do
+        let (:service_id) { '6666' }
+
+        it 'Trying to create/update the application' do
+          ThreeScale::Backend::Service.save! id: service_id, provider_key: 'bar', state: :suspended
+
+          post "/services/#{service_id}/applications/#{id}", { application: }.to_json
+
+          expect(status).to eq 201
+          expect(response_json['status']).to eq 'created'
+        end
+      end
     end
 
-    context 'with an application that does not exist' do
-      let(:non_existing_id) { '101' }
+    context 'PUT' do
+      let(:service_id) { '7575' }
+      let(:id) { '100' }
+      let(:plan_id) { '101' }
+      let(:plan_name) { 'some_other_plan' }
+      let(:state) { :active }
+      let(:redirect_url) { 'https://3scale.net' }
+      let(:application) do
+        {
+          service_id: service_id,
+          id: id,
+          plan_id: plan_id,
+          plan_name: plan_name,
+          state: state,
+          redirect_url: redirect_url
+        }
+      end
 
-      example 'creating the application' do
-        do_request(id: non_existing_id)
+      context 'with an application that exists' do
+        it 'updating the application' do
+          put "/services/#{service_id}/applications/#{id}", { application: }.to_json
+
+          expect(status).to eq 200
+          expect(response_json['status']).to eq 'modified'
+
+          app = ThreeScale::Backend::Application.load(service_id, id)
+          expect(app.to_hash).to eq application
+        end
+
+        it 'updating the application with extra params that should be ignored' do
+          application_param = application.merge(some_param: 'some_val')
+
+          put "/services/#{service_id}/applications/#{id}", { application: application_param }.to_json
+
+          expect(status).to eq 200
+          expect(response_json['status']).to eq 'modified'
+
+          app = ThreeScale::Backend::Application.load(service_id, id)
+          expect(app).not_to be_nil
+          expect(app).not_to respond_to :some_param
+          # The returned data should not contain *some_param* attribute
+          expect(app.to_hash).to eq application
+        end
+      end
+
+      context 'with an application that does not exist' do
+        let(:non_existing_id) { '101' }
+
+        it 'creating the application' do
+          put "/services/#{service_id}/applications/#{non_existing_id}", { application: }.to_json
+
+          expect(status).to eq 200
+          expect(response_json['status']).to eq 'created'
+
+          app = ThreeScale::Backend::Application.load(service_id, non_existing_id)
+          expect(app.to_hash).to eq application.merge(id: non_existing_id)
+        end
+      end
+
+      context 'without specifying the application' do
+        let(:application) { nil }
+
+        it 'trying to update the application' do
+          put "/services/#{service_id}/applications/#{id}", { application: }.to_json
+
+          expect(status).to eq 400
+          expect(response_json['status']).to eq 'error'
+          expect(response_json['error']).to match /missing parameter/i
+        end
+      end
+
+      context 'with an application that has no state' do
+        let (:state) { nil }
+
+        it 'Trying to create/update the application' do
+          put "/services/#{service_id}/applications/#{id}", { application: }.to_json
+
+          expect(status).to eq 400
+          expect(response_json['status']).to eq 'bad_request'
+          expect(response_json['error']).to match /has no state/i
+        end
+      end
+
+      context 'with a disabled service' do
+        let (:service_id) { '6666' }
+
+        it 'Trying to create/update the application' do
+          ThreeScale::Backend::Service.save! id: service_id, provider_key: 'bar', state: :suspended
+
+          put "/services/#{service_id}/applications/#{id}", { application: }.to_json
+
+          expect(status).to eq 200
+          expect(response_json['status']).to eq 'created'
+        end
+      end
+    end
+
+    context 'DELETE' do
+      let(:service_id) { '7575' }
+      let(:id) { '100' }
+      it 'Deleting an application' do
+        delete "/services/#{service_id}/applications/#{id}"
 
         expect(status).to eq 200
-        expect(response_json['status']).to eq 'created'
-
-        app = ThreeScale::Backend::Application.load(service_id, non_existing_id)
-        expect(app.to_hash).to eq application.merge(id: non_existing_id)
+        expect(response_json['status']).to eq 'deleted'
       end
     end
+  end
 
-    context 'without specifying the application' do
-      let(:application) { nil }
+  context '/services/:service_id/applications/key/:user_key' do
 
-      example_request 'trying to update the application' do
-        expect(status).to eq 400
-        expect(response_json['status']).to eq 'error'
-        expect(response_json['error']).to match /missing parameter/i
-      end
-    end
+    # XXX Old API. DEPRECATED.
+    context 'GET' do
+      let(:service_id) { '7575' }
+      let(:id) { '100' }
+      let(:user_key) { 'some_key' }
+      let(:nonexistent_key) { 'nonexistent' }
 
-    context 'with an application that has no state' do
-      let (:state) { nil }
+      it 'Get existing ID of Application with service and key' do
+        ThreeScale::Backend::Application.save_id_by_key(service_id, user_key, id)
 
-      example_request 'Trying to create/update the application' do
-        expect(status).to eq 400
-        expect(response_json['status']).to eq 'bad_request'
-        expect(response_json['error']).to match /has no state/i
-      end
-    end
+        get "/services/#{service_id}/applications/key/#{user_key}"
 
-    context 'with a disabled service' do
-      let (:service_id) { '6666' }
-
-      example 'Trying to create/update the application' do
-        ThreeScale::Backend::Service.save! id: service_id, provider_key: 'bar', state: :suspended
-        do_request
         expect(status).to eq 200
-        expect(response_json['status']).to eq 'created'
+        expect(response_json['application']['id']).to eq id
+      end
+
+      it 'Try to get an Application ID from a non-existing key' do
+        ThreeScale::Backend::Application.delete_id_by_key(service_id, nonexistent_key)
+
+        get "/services/#{service_id}/applications/key/#{nonexistent_key}"
+
+        expect(status).to eq 404
+        expect(response_json['error']).to match /not found/i
+      end
+    end
+
+    context 'DELETE' do
+      let(:service_id) { '7575' }
+      let(:id) { '100' }
+      let(:user_key) { 'some_key' }
+
+      it 'Delete an Application\'s user key' do
+        ThreeScale::Backend::Application.save_id_by_key(service_id, user_key, id)
+
+        delete "/services/#{service_id}/applications/key/#{user_key}"
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'deleted'
+        expect(ThreeScale::Backend::Application.
+          load_id_by_key(service_id, user_key)).to be nil
       end
     end
   end
 
-  delete '/services/:service_id/applications/:id' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Application ID', required: true
-
-    let(:service_id) { '7575' }
-    let(:id) { '100' }
-    example_request 'Deleting an application' do
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'deleted'
-    end
-
-  end
-
-  # XXX Old API. DEPRECATED.
-  get '/services/:service_id/applications/key/:user_key' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :user_key, 'User key for this Application', required: true
-
-    let(:service_id) { '7575' }
-    let(:id) { '100' }
-    let(:user_key) { 'some_key' }
-    let(:nonexistent_key) { 'nonexistent' }
-
-    example 'Get existing ID of Application with service and key' do
-      ThreeScale::Backend::Application.save_id_by_key(service_id, user_key, id)
-      do_request
-      expect(status).to eq 200
-      expect(response_json['application']['id']).to eq id
-    end
-
-    example 'Try to get an Application ID from a non-existing key' do
-      ThreeScale::Backend::Application.delete_id_by_key(service_id, nonexistent_key)
-      do_request user_key: nonexistent_key
-      expect(status).to eq 404
-      expect(response_json['error']).to match /not found/i
-    end
-  end
-
-  put '/services/:service_id/applications/:id/key/:user_key' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Application ID', required: true
-    parameter :user_key, 'User key for this Application', required: true
-
+  describe 'PUT /services/:service_id/applications/:id/key/:user_key' do
     let(:service_id) { '7575' }
     let(:id) { '100' }
     let(:user_key) { 'some_key' }
     let(:another_key) { 'another_key' }
 
-    example 'Change the key for an Application' do
+    it 'Change the key for an Application' do
       ThreeScale::Backend::Application.save_id_by_key(service_id, user_key, id)
-      do_request user_key: another_key
+
+      put "/services/#{service_id}/applications/#{id}/key/#{another_key}"
+
       expect(status).to eq 200
       expect(response_json['status']).to eq 'modified'
       expect(ThreeScale::Backend::Application.
         load_id_by_key(service_id, another_key)).to eq id
-    end
-  end
-
-  delete '/services/:service_id/applications/key/:user_key' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :user_key, 'User key for this Application', required: true
-
-    let(:service_id) { '7575' }
-    let(:id) { '100' }
-    let(:user_key) { 'some_key' }
-
-    example 'Delete an Application\'s user key' do
-      ThreeScale::Backend::Application.save_id_by_key(service_id, user_key, id)
-      do_request
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'deleted'
-      expect(ThreeScale::Backend::Application.
-        load_id_by_key(service_id, user_key)).to be nil
     end
   end
 end

--- a/spec/acceptance/api/internal/errors_api_spec.rb
+++ b/spec/acceptance/api/internal/errors_api_spec.rb
@@ -1,196 +1,206 @@
 require 'timecop'
 
-resource 'Errors (prefix: /services/:service_id/errors)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
-
+describe 'Errors (prefix: /services/:service_id/errors)' do
   let(:service_id) { '7575' }
   let(:service_id_non_existent) { service_id.to_i.succ.to_s }
 
   before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+
     ThreeScale::Backend::Service.save!(provider_key: 'foo', id: service_id)
     ThreeScale::Backend::ErrorStorage.delete_all(service_id)
   end
 
-  get '/services/:service_id/errors/' do
-    parameter :service_id, 'Service ID', required: true
+  context '/services/:service_id/errors' do
+    context 'GET' do
+      context 'when there are no errors' do
+        it 'Get errors by service ID' do
+          get "/services/#{service_id}/errors/"
 
-    context 'when there are no errors' do
-      example_request 'Get errors by service ID' do
-        expect(response_json['errors']).to be_empty
-        expect(response_json['count']).to be_zero
-        expect(response_status).to eq(200)
+          expect(response_json['errors']).to be_empty
+          expect(response_json['count']).to be_zero
+          expect(response_status).to eq(200)
+        end
       end
-    end
 
-    context 'when there are errors but do not care about pagination' do
-      let(:test_time) { Time.utc(2010, 9, 3, 17, 9) }
+      context 'when there are errors but do not care about pagination' do
+        let(:test_time) { Time.utc(2010, 9, 3, 17, 9) }
 
-      before do
-        Timecop.freeze(test_time) do
-          ThreeScale::Backend::ErrorStorage.store(
+        before do
+          Timecop.freeze(test_time) do
+            ThreeScale::Backend::ErrorStorage.store(
               service_id, ThreeScale::Backend::ApplicationNotFound.new('boo'))
+          end
+        end
+
+        it 'Get errors by service ID' do
+          get "/services/#{service_id}/errors/"
+
+          error = response_json['errors'].first
+          expect(error['code']).to eq ('application_not_found')
+          expect(error['message']).to eq('application with id="boo" was not found')
+          expect(error['timestamp']).to eq(test_time.to_s)
+          expect(response_json['count']).to eq(1)
+          expect(response_status).to eq(200)
+        end
+
+        it 'Try with invalid service ID' do
+          get "/services/#{service_id_non_existent}/errors/"
+
+          expect(response_status).to eq(404)
         end
       end
 
-      example_request 'Get errors by service ID' do
-        error = response_json['errors'].first
-        expect(error['code']).to eq ('application_not_found')
-        expect(error['message']).to eq('application with id="boo" was not found')
-        expect(error['timestamp']).to eq(test_time.to_s)
-        expect(response_json['count']).to eq(1)
-        expect(response_status).to eq(200)
-      end
+      context 'when there are multiple errors and want to use pagination' do
+        let(:provider_key_invalid_errors) { ThreeScale::Backend::ErrorStorage::PER_PAGE }
+        let(:metric_invalid_errors) { 2 }
+        let(:usage_value_invalid_errors) { 3 }
+        let(:application_not_found_errors) { usage_value_invalid_errors }
+        let(:errors_per_page) { usage_value_invalid_errors }
 
-      example 'Try with invalid service ID' do
-        do_request(service_id: service_id_non_existent)
-        expect(response_status).to eq(404)
-      end
-    end
-
-    context 'when there are multiple errors and want to use pagination' do
-      let(:provider_key_invalid_errors) { ThreeScale::Backend::ErrorStorage::PER_PAGE }
-      let(:metric_invalid_errors) { 2 }
-      let(:usage_value_invalid_errors) { 3 }
-      let(:application_not_found_errors) { usage_value_invalid_errors }
-      let(:errors_per_page) { usage_value_invalid_errors }
-
-      let(:test_errors) do
-        errors = Array.new(provider_key_invalid_errors) do
-          ThreeScale::Backend::ProviderKeyInvalid.new('test_app')
+        let(:test_errors) do
+          errors = Array.new(provider_key_invalid_errors) do
+            ThreeScale::Backend::ProviderKeyInvalid.new('test_app')
+          end
+          metric_invalid_errors.times do
+            errors << ThreeScale::Backend::MetricInvalid.new('foo')
+          end
+          usage_value_invalid_errors.times do
+            errors << ThreeScale::Backend::UsageValueInvalid.new('hits', 'lots')
+          end
+          application_not_found_errors.times do
+            errors << ThreeScale::Backend::ApplicationNotFound.new('boo')
+          end
+          errors
         end
-        metric_invalid_errors.times do
-          errors << ThreeScale::Backend::MetricInvalid.new('foo')
+
+        before do
+          test_errors.each do |error|
+            ThreeScale::Backend::ErrorStorage.store(service_id, error)
+          end
         end
-        usage_value_invalid_errors.times do
-          errors << ThreeScale::Backend::UsageValueInvalid.new('hits', 'lots')
+
+        it 'Get errors without specifying page nor errors per page' do
+          get "/services/#{service_id}/errors/"
+
+          expect(response_json['errors'].size).to eq(ThreeScale::Backend::ErrorStorage::PER_PAGE)
+          expect(response_json['count']).to eq(test_errors.size)
+          expect(response_status).to eq(200)
         end
-        application_not_found_errors.times do
-          errors << ThreeScale::Backend::ApplicationNotFound.new('boo')
+
+        example 'Get errors of page #1' do
+          get "/services/#{service_id}/errors/", page: 1, per_page: errors_per_page
+
+          expect(response_json['errors'].first['code']).to eq('application_not_found')
+          expect(response_json['errors'].size).to eq(errors_per_page)
+          expect(response_json['count']).to eq(test_errors.size)
+          expect(response_status).to eq(200)
         end
-        errors
-      end
 
-      before do
-        test_errors.each do |error|
-          ThreeScale::Backend::ErrorStorage.store(service_id, error)
+        example 'Get errors of page #2' do
+          get "/services/#{service_id}/errors/", page: 2, per_page: errors_per_page
+
+          expect(response_json['errors'].first['code']).to eq('usage_value_invalid')
+          expect(response_json['errors'].size).to eq(errors_per_page)
+          expect(response_json['count']).to eq(test_errors.size)
+          expect(response_status).to eq(200)
+        end
+
+        example 'Get errors of page #3' do
+          get "/services/#{service_id}/errors/", page: 3, per_page: errors_per_page
+
+          expect(response_json['errors'].first['code']).to eq('metric_invalid')
+          expect(response_json['errors'].size).to eq(errors_per_page)
+          expect(response_json['count']).to eq(test_errors.size)
+          expect(response_status).to eq(200)
+        end
+
+        example 'Try specifying page with no elements' do
+          get "/services/#{service_id}/errors/", page: 2, per_page: test_errors.size + 1
+
+          expect(response_json['errors']).to be_empty
+          expect(response_json['count']).to eq(test_errors.size)
+          expect(response_status).to eq(200)
+        end
+
+        example 'Try with last page having just one error' do
+          get "/services/#{service_id}/errors/", page: 2, per_page: test_errors.size - 1
+
+          expect(response_json['errors'].first['code']).to eq('provider_key_invalid')
+          expect(response_json['errors'].size).to eq(1)
+          expect(response_json['count']).to eq(test_errors.size)
+        end
+
+        example 'Try with negative per_page value' do
+          get "/services/#{service_id}/errors/", page: 1, per_page: -1
+
+          expect(response_status).to eq(400)
         end
       end
-
-      example_request 'Get errors without specifying page nor errors per page' do
-        expect(response_json['errors'].size).to eq(ThreeScale::Backend::ErrorStorage::PER_PAGE)
-        expect(response_json['count']).to eq(test_errors.size)
-        expect(response_status).to eq(200)
-      end
-
-      example 'Get errors of page #1' do
-        do_request(page: 1, per_page: errors_per_page)
-        expect(response_json['errors'].first['code']).to eq('application_not_found')
-        expect(response_json['errors'].size).to eq(errors_per_page)
-        expect(response_json['count']).to eq(test_errors.size)
-        expect(response_status).to eq(200)
-      end
-
-      example 'Get errors of page #2' do
-        do_request(page: 2, per_page: errors_per_page)
-        expect(response_json['errors'].first['code']).to eq('usage_value_invalid')
-        expect(response_json['errors'].size).to eq(errors_per_page)
-        expect(response_json['count']).to eq(test_errors.size)
-        expect(response_status).to eq(200)
-      end
-
-      example 'Get errors of page #3' do
-        do_request(page: 3, per_page: errors_per_page)
-        expect(response_json['errors'].first['code']).to eq('metric_invalid')
-        expect(response_json['errors'].size).to eq(errors_per_page)
-        expect(response_json['count']).to eq(test_errors.size)
-        expect(response_status).to eq(200)
-      end
-
-      example 'Try specifying page with no elements' do
-        do_request(page: 2, per_page: test_errors.size + 1)
-        expect(response_json['errors']).to be_empty
-        expect(response_json['count']).to eq(test_errors.size)
-        expect(response_status).to eq(200)
-      end
-
-      example 'Try with last page having just one error' do
-        do_request(page: 2, per_page: test_errors.size - 1)
-        expect(response_json['errors'].first['code']).to eq('provider_key_invalid')
-        expect(response_json['errors'].size).to eq(1)
-        expect(response_json['count']).to eq(test_errors.size)
-      end
-
-      example 'Try with negative per_page value' do
-        do_request(page: 1, per_page: -1)
-        expect(response_status).to eq(400)
-      end
-    end
-  end
-
-  delete '/services/:service_id/errors/' do
-    parameter :service_id, 'Service ID', required: true
-
-    context 'when there are no errors' do
-      example_request 'Delete all errors' do
-        expect(response_status).to eq(200)
-        expect(ThreeScale::Backend::ErrorStorage.list(service_id)).to be_empty
-      end
     end
 
-    context 'when there are errors' do
-      before do
-        3.times { ThreeScale::Backend::ErrorStorage.store(
-            service_id, ThreeScale::Backend::ApplicationNotFound.new('boo')) }
+    context 'POST' do
+      let(:example_error_messages) do
+        %w(error_msg_#1 error_msg_#2 error_msg_#3)
       end
 
-      example_request 'Delete all errors' do
-        expect(response_status).to eq(200)
-        expect(ThreeScale::Backend::ErrorStorage.list(service_id)).to be_empty
-      end
+      context 'when the service exists' do
+        it 'Save errors' do
+          post "/services/#{service_id}/errors/", { errors: example_error_messages }.to_json
 
-      example 'Try with invalid service ID' do
-        do_request(service_id: service_id_non_existent)
-        expect(response_status).to eq(404)
-        expect(ThreeScale::Backend::ErrorStorage.list(service_id_non_existent)).to be_empty
-      end
-    end
-  end
-
-  post '/services/:service_id/errors/' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :errors, 'Errors', required: false
-
-    let(:example_error_messages) do
-      %w(error_msg_#1 error_msg_#2 error_msg_#3)
-    end
-
-    define_method :raw_post do
-      params.to_json
-    end
-
-    context 'when the service exists' do
-      example 'Save errors' do
-        do_request(service_id: service_id, errors: example_error_messages)
-
-        saved_errors = ThreeScale::Backend::ErrorStorage.list(service_id)
-        expect(saved_errors.map { |error| error[:message] })
+          saved_errors = ThreeScale::Backend::ErrorStorage.list(service_id)
+          expect(saved_errors.map { |error| error[:message] })
             .to eq example_error_messages.reverse
 
-        expect(response_status).to eq(201)
+          expect(response_status).to eq(201)
+        end
+
+        it 'Try without specifying errors' do
+          post "/services/#{service_id}/errors/"
+
+          expect(response_status).to eq(400)
+        end
       end
 
-      example 'Try without specifying errors' do
-        do_request(service_id: service_id)
-        expect(response_status).to eq(400)
+      context 'when the service does not exist' do
+        it 'Try to save errors' do
+          post "/services/#{service_id_non_existent}/errors/", { errors: example_error_messages }.to_json
+
+          expect(response_status).to eq(404)
+        end
       end
     end
 
-    context 'when the service does not exist' do
-      example 'Try to save errors' do
-        do_request(service_id: service_id_non_existent,
-                   errors: example_error_messages)
-        expect(response_status).to eq(404)
+    context 'DELETE' do
+      context 'when there are no errors' do
+        it 'Delete all errors' do
+          delete "/services/#{service_id}/errors/"
+
+          expect(response_status).to eq(200)
+          expect(ThreeScale::Backend::ErrorStorage.list(service_id)).to be_empty
+        end
+      end
+
+      context 'when there are errors' do
+        before do
+          3.times { ThreeScale::Backend::ErrorStorage.store(
+            service_id, ThreeScale::Backend::ApplicationNotFound.new('boo')) }
+        end
+
+        it 'Delete all errors' do
+          delete "/services/#{service_id}/errors/"
+
+          expect(response_status).to eq(200)
+          expect(ThreeScale::Backend::ErrorStorage.list(service_id)).to be_empty
+        end
+
+        it 'Try with invalid service ID' do
+          delete "/services/#{service_id_non_existent}/errors/"
+
+          expect(response_status).to eq(404)
+          expect(ThreeScale::Backend::ErrorStorage.list(service_id_non_existent)).to be_empty
+        end
       end
     end
   end

--- a/spec/acceptance/api/internal/events_api_spec.rb
+++ b/spec/acceptance/api/internal/events_api_spec.rb
@@ -1,39 +1,128 @@
-resource 'Events' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
+describe 'Events' do
+  before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+  end
 
   let(:first_traffic_event) { { foo: 'bar' } }
   let(:alert_event) { { utilization: 'foo' } }
 
-  get '/events/' do
-    context 'when there are no events' do
-      example_request 'Getting events' do
-        expect(response_status).to eq(200)
-        expect(response_json['events']).to eq([])
+  context '/events/' do
+    context 'GET' do
+      context 'when there are no events' do
+        it 'Getting events' do
+          get '/events/'
+
+          expect(response_status).to eq(200)
+          expect(response_json['events']).to eq([])
+        end
+      end
+
+      context 'when there are events' do
+        before do
+          ThreeScale::Backend::EventStorage.store(:first_traffic, first_traffic_event)
+          ThreeScale::Backend::EventStorage.store(:alert, alert_event)
+        end
+
+        it 'Getting events', document: false do
+          get '/events/'
+
+          expect(response_status).to eq(200)
+          expect(response_json['events'].size).to eq(2)
+          expect(response_json['events'].first['type']).to eq('first_traffic')
+          expect(response_json['events'].first['object']).to eq(first_traffic_event.stringify_keys)
+          expect(response_json['events'].last['type']).to eq('alert')
+          expect(response_json['events'].last['object']).to eq(alert_event.stringify_keys)
+        end
       end
     end
 
-    context 'when there are events' do
-      before do
-        ThreeScale::Backend::EventStorage.store(:first_traffic, first_traffic_event)
-        ThreeScale::Backend::EventStorage.store(:alert, alert_event)
+    context 'POST' do
+      let(:current_last_event_id) do
+        if ThreeScale::Backend::EventStorage.list.last
+          ThreeScale::Backend::EventStorage.list.last[:id]
+        else
+          nil
+        end
+      end
+      let(:example_events) do
+        [{ type: :first_traffic, object: first_traffic_event },
+         { type: :alert, object: alert_event }]
       end
 
-      example 'Getting events', document: false do
-        do_request
+      before do
+        if current_last_event_id
+          ThreeScale::Backend::EventStorage.delete(current_last_event_id)
+        end
+      end
 
-        expect(response_status).to eq(200)
-        expect(response_json['events'].size).to eq(2)
-        expect(response_json['events'].first['type']).to eq('first_traffic')
-        expect(response_json['events'].first['object']).to eq(first_traffic_event.stringify_keys)
-        expect(response_json['events'].last['type']).to eq('alert')
-        expect(response_json['events'].last['object']).to eq(alert_event.stringify_keys)
+      context 'when some events are sent' do
+        it 'Save events' do
+          post '/events/', { events: example_events }.to_json
+
+          events = ThreeScale::Backend::EventStorage.list
+
+          expect(events.size).to eq(example_events.size)
+
+          expect(events[0][:type]).to eq(example_events[0][:type].to_s)
+          expect(events[0][:object]).to eq(example_events[0][:object])
+          expect(events[1][:type]).to eq(example_events[1][:type].to_s)
+          expect(events[1][:object]).to eq(example_events[1][:object])
+
+          expect(response_status).to eq(201)
+        end
+      end
+
+      context 'when no events are sent' do
+        it 'Try to save events' do
+          post '/events/'
+
+          expect(response_status).to eq(400)
+        end
+      end
+    end
+
+    context 'DELETE' do
+      context 'when there are errors to delete' do
+        before do
+          4.times do
+            ThreeScale::Backend::EventStorage.store(:first_traffic, first_traffic_event)
+          end
+        end
+
+        let(:upto_id) { ThreeScale::Backend::EventStorage.list.last[:id] }
+        it "Delete events by Range" do
+          delete '/events/', { upto_id: }.to_json
+
+          expect(response_status).to eq(200)
+          expect(response_json['status']).to eq('deleted')
+          expect(response_json['num_events']).to eq(4)
+        end
+
+        it "Delete a subset of events by Range", document: false do
+          delete '/events/', { upto_id: ThreeScale::Backend::EventStorage.list[1][:id], parameters: { foo: :bar } }.to_json
+
+          expect(response_status).to eq(200)
+          expect(response_json['status']).to eq('deleted')
+          expect(response_json['num_events']).to eq(2)
+        end
+      end
+
+      context 'when there are no errors to delete' do
+        let(:upto_id) { 0 }
+
+        it "Delete Events by Range" do
+          delete '/events/', { upto_id: }.to_json
+
+          expect(response_status).to eq(200)
+          expect(response_json['status']).to eq('deleted')
+          expect(response_json['num_events']).to eq(0)
+        end
       end
     end
   end
 
-  delete '/events/:id' do
-    parameter :id, "Event ID", required: true
+  context 'DELETE /events/:id' do
 
     before do
       ThreeScale::Backend::EventStorage.store(:first_traffic, first_traffic_event)
@@ -42,7 +131,9 @@ resource 'Events' do
     context 'when the event exists' do
       let(:id) { ThreeScale::Backend::EventStorage.list.first[:id] }
 
-      example_request "Delete Event by ID" do
+      it "Delete Event by ID" do
+        delete "/events/#{id}"
+
         expect(response_status).to eq(200)
         expect(response_json['status']).to eq('deleted')
       end
@@ -51,94 +142,11 @@ resource 'Events' do
     context 'when the event doesn\'t exist' do
       let(:id) { 0 }
 
-      example "Delete Event by ID", document: false do
-        do_request
+      it "Delete Event by ID", document: false do
+        delete "/events/#{id}"
 
         expect(response_status).to eq(404)
         expect(response_json['status']).to eq('not_found')
-      end
-    end
-  end
-
-  delete '/events/' do
-    parameter :upto_id, "ID of the last event of the range", required: true
-
-    context 'when there are errors to delete' do
-      before do
-        4.times do
-          ThreeScale::Backend::EventStorage.store(:first_traffic, first_traffic_event)
-        end
-      end
-
-      let(:upto_id) { ThreeScale::Backend::EventStorage.list.last[:id] }
-      example_request "Delete events by Range" do
-
-        expect(response_status).to eq(200)
-        expect(response_json['status']).to eq('deleted')
-        expect(response_json['num_events']).to eq(4)
-      end
-
-      example "Delete a subset of events by Range", document: false do
-        do_request(upto_id: ThreeScale::Backend::EventStorage.list[1][:id], parameters: { foo: :bar })
-
-        expect(response_status).to eq(200)
-        expect(response_json['status']).to eq('deleted')
-        expect(response_json['num_events']).to eq(2)
-      end
-    end
-
-    context 'when there are no errors to delete' do
-      let(:upto_id) { 0 }
-
-      example_request "Delete Events by Range" do
-        expect(response_status).to eq(200)
-        expect(response_json['status']).to eq('deleted')
-        expect(response_json['num_events']).to eq(0)
-      end
-    end
-  end
-
-  post '/events/' do
-    parameter :events, 'Events', required: false
-
-    let(:raw_post) { params.to_json }
-    let(:current_last_event_id) do
-      if ThreeScale::Backend::EventStorage.list.last
-        ThreeScale::Backend::EventStorage.list.last[:id]
-      else
-        nil
-      end
-    end
-    let(:example_events) do
-      [{ type: :first_traffic, object: first_traffic_event },
-       { type: :alert, object: alert_event }]
-    end
-
-    before do
-      if current_last_event_id
-        ThreeScale::Backend::EventStorage.delete(current_last_event_id)
-      end
-    end
-
-    context 'when some events are sent' do
-      example 'Save events' do
-        do_request(events: example_events)
-        events = ThreeScale::Backend::EventStorage.list
-
-        expect(events.size).to eq(example_events.size)
-
-        expect(events[0][:type]).to eq(example_events[0][:type].to_s)
-        expect(events[0][:object]).to eq(example_events[0][:object])
-        expect(events[1][:type]).to eq(example_events[1][:type].to_s)
-        expect(events[1][:object]).to eq(example_events[1][:object])
-
-        expect(response_status).to eq(201)
-      end
-    end
-
-    context 'when no events are sent' do
-      example_request 'Try to save events' do
-        expect(response_status).to eq(400)
       end
     end
   end

--- a/spec/acceptance/api/internal/internal_api_spec.rb
+++ b/spec/acceptance/api/internal/internal_api_spec.rb
@@ -1,24 +1,33 @@
-resource 'Internal API (prefix: /internal)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
+describe 'Internal API (prefix: /internal)' do
 
-  get '/unknown/route/no/one/would/ever/try/to/use/in/a/real/app/omg' do
-    example_request 'Check that unknown routes return proper 404' do
+  before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+  end
+
+  context 'GET /unknown/route/no/one/would/ever/try/to/use/in/a/real/app/omg' do
+    it 'Check that unknown routes return proper 404' do
+      get '/unknown/route/no/one/would/ever/try/to/use/in/a/real/app/omg'
+
       expect(status).to eq 404
       expect(response_json['status']).to eq 'not_found'
       expect(response_json['error']).to eq 'Not found'
     end
   end
 
-  get '/check.json' do
-    example_request 'Check internal API live status' do
+  context 'GET /check.json' do
+    it 'Check internal API live status' do
+      get '/check.json'
+
       expect(status).to eq 200
       expect(response_json['status']).to eq 'ok'
     end
   end
 
-  get '/status' do
-    example_request 'Get Backend\'s version' do
+  context 'GET /status' do
+    it 'Get Backend\'s version' do
+      get '/status'
+
       expect(status).to eq 200
       expect(response_json['status']).to eq 'ok'
       expect(response_json['version']['backend']).to eq ThreeScale::Backend::VERSION

--- a/spec/acceptance/api/internal/metrics_api_spec.rb
+++ b/spec/acceptance/api/internal/metrics_api_spec.rb
@@ -1,135 +1,130 @@
-resource 'Metrics (prefix: /services/:service_id/metrics)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
-
+describe 'Metrics (prefix: /services/:service_id/metrics)' do
   before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+
     ThreeScale::Backend::Metric.delete('7575', '100')
     @metric = ThreeScale::Backend::Metric.save(service_id: '7575', id: '100',
                                                  name: 'hits')
   end
 
-  get '/services/:service_id/metrics/:id' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Metric ID', required: true
+  context '/services/:service_id/metrics/:id' do
+    context 'GET' do
+      let(:service_id) { '7575' }
+      let(:id) { '100' }
+      let(:service_id_non_existent) { service_id.to_i.succ.to_s }
+      let(:id_non_existent) { id.to_i.succ.to_s }
 
-    let(:service_id) { '7575' }
-    let(:id) { '100' }
-    let(:service_id_non_existent) { service_id.to_i.succ.to_s }
-    let(:id_non_existent) { id.to_i.succ.to_s }
+      it 'Get Metric by ID' do
+        get "/services/#{service_id}/metrics/#{id}"
 
-    example_request 'Get Metric by ID' do
-      expect(response_json['metric']['id']).to eq id
-      expect(response_json['metric']['service_id']).to eq service_id
-      expect(status).to eq 200
+        expect(response_json['metric']['id']).to eq id
+        expect(response_json['metric']['service_id']).to eq service_id
+        expect(status).to eq 200
+      end
+
+      it 'Try to get a Metric by non-existent ID' do
+        get "/services/#{service_id}/metrics/#{id_non_existent}"
+
+        expect(status).to eq 404
+        expect(response_json['error']).to match /metric not found/i
+      end
+
+      it 'Try to get a Metric by non-existent service ID' do
+        get "/services/#{service_id_non_existent}/metrics/#{id}"
+
+        expect(status).to eq 404
+        expect(response_json['error']).to match /metric not found/i
+      end
     end
 
-    example 'Try to get a Metric by non-existent ID' do
-      do_request id: id_non_existent
-      expect(status).to eq 404
-      expect(response_json['error']).to match /metric not found/i
+    context 'POST' do
+      let(:service_id) { '7575' }
+      let(:id) { '200' }
+      let(:name) { 'rqps' }
+      let(:metric) do
+        {
+          service_id: service_id,
+          id: id,
+          name: name,
+        }
+      end
+
+      it 'Create a Metric' do
+        post "/services/#{service_id}/metrics/#{id}", { metric: }.to_json
+
+        expect(status).to eq 201
+        expect(response_json['status']).to eq 'created'
+
+        metric = ThreeScale::Backend::Metric.load(service_id, id)
+        expect(metric.id).to eq id
+        expect(metric.service_id).to eq service_id
+        expect(metric.name).to eq name
+      end
+
+      it 'Create a Metric with extra params' do
+        post "/services/#{service_id}/metrics/#{id}", { metric: metric.merge(some_param: 'some_val') }.to_json
+
+        expect(status).to eq 201
+        expect(response_json['status']).to eq 'created'
+
+        metric = ThreeScale::Backend::Metric.load(service_id, id)
+        expect(metric).not_to be_nil
+        expect(metric).not_to respond_to :some_param
+        expect(metric.id).to eq id
+        expect(metric.service_id).to eq service_id
+        expect(metric.name).to eq name
+      end
     end
 
-    example 'Try to get a Metric by non-existent service ID' do
-      do_request service_id: service_id_non_existent
-      expect(status).to eq 404
-      expect(response_json['error']).to match /metric not found/i
+    context 'PUT' do
+      let(:service_id) { '7575' }
+      let(:id) { '100' }
+      let(:name) { 'response_time' }
+      let(:metric) do
+        {
+          service_id: service_id,
+          id: id,
+          name: name,
+        }
+      end
+
+      it 'Update Metric by ID' do
+        put "/services/#{service_id}/metrics/#{id}", { metric: }.to_json
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'modified'
+
+        metric = ThreeScale::Backend::Metric.load(service_id, id)
+        expect(metric.id).to eq id
+        expect(metric.service_id).to eq service_id
+        expect(metric.name).to eq name
+      end
+
+      it 'Update Metric by ID using extra params' do
+        put "/services/#{service_id}/metrics/#{id}", { metric: metric.merge(some_param: 'some_val') }.to_json
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'modified'
+
+        metric = ThreeScale::Backend::Metric.load(service_id, id)
+        expect(metric).not_to be_nil
+        expect(metric).not_to respond_to :some_param
+        expect(metric.id).to eq id
+        expect(metric.service_id).to eq service_id
+        expect(metric.name).to eq name
+      end
+    end
+
+    context 'DELETE' do
+      let(:service_id) { '7575' }
+      let(:id) { '100' }
+      it 'Deleting a Metric' do
+        delete "/services/#{service_id}/metrics/#{id}"
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'deleted'
+      end
     end
   end
-
-  post '/services/:service_id/metrics/:id' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Metric ID', required: true
-    parameter :metric, 'Metric attributes', required: true
-
-    let(:service_id) { '7575' }
-    let(:id) { '200' }
-    let(:name) { 'rqps' }
-    let(:metric) do
-      {
-        service_id: service_id,
-        id: id,
-        name: name,
-      }
-    end
-    let(:raw_post){ params.to_json }
-
-    example_request 'Create a Metric' do
-      expect(status).to eq 201
-      expect(response_json['status']).to eq 'created'
-
-      metric = ThreeScale::Backend::Metric.load(service_id, id)
-      expect(metric.id).to eq id
-      expect(metric.service_id).to eq service_id
-      expect(metric.name).to eq name
-    end
-
-    example 'Create a Metric with extra params' do
-      do_request metric: metric.merge(some_param: 'some_val')
-      expect(status).to eq 201
-      expect(response_json['status']).to eq 'created'
-
-      metric = ThreeScale::Backend::Metric.load(service_id, id)
-      expect(metric).not_to be_nil
-      expect(metric).not_to respond_to :some_param
-      expect(metric.id).to eq id
-      expect(metric.service_id).to eq service_id
-      expect(metric.name).to eq name
-    end
-
-  end
-
-  put '/services/:service_id/metrics/:id' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Metric ID', required: true
-    parameter :metric, 'Metric attributes', required: true
-
-    let(:service_id) { '7575' }
-    let(:id) { '100' }
-    let(:name) { 'response_time' }
-    let(:metric) do
-      {
-        service_id: service_id,
-        id: id,
-        name: name,
-      }
-    end
-    let(:raw_post){ params.to_json }
-
-    example_request 'Update Metric by ID' do
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'modified'
-
-      metric = ThreeScale::Backend::Metric.load(service_id, id)
-      expect(metric.id).to eq id
-      expect(metric.service_id).to eq service_id
-      expect(metric.name).to eq name
-    end
-
-    example 'Update Metric by ID using extra params' do
-      do_request metric: metric.merge(some_param: 'some_val')
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'modified'
-
-      metric = ThreeScale::Backend::Metric.load(service_id, id)
-      expect(metric).not_to be_nil
-      expect(metric).not_to respond_to :some_param
-      expect(metric.id).to eq id
-      expect(metric.service_id).to eq service_id
-      expect(metric.name).to eq name
-    end
-  end
-
-  delete '/services/:service_id/metrics/:id' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :id, 'Metric ID', required: true
-
-    let(:service_id) { '7575' }
-    let(:id) { '100' }
-    example_request 'Deleting a Metric' do
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'deleted'
-    end
-
-  end
-
 end

--- a/spec/acceptance/api/internal/service_tokens_api_spec.rb
+++ b/spec/acceptance/api/internal/service_tokens_api_spec.rb
@@ -1,26 +1,26 @@
-resource 'Service Tokens (prefix: /service_tokens)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
+describe 'Service Tokens (prefix: /service_tokens)' do
 
   # This is just so we check the messages just once and use constants from there
   before(:all) do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+
     expect(ThreeScale::Backend::ServiceToken::InvalidServiceToken.new.message)
         .to eq 'Service token cannot be blank'
     expect(ThreeScale::Backend::ServiceToken::InvalidServiceId.new.message)
         .to eq 'Service ID cannot be blank'
   end
 
-  head '/service_tokens/:token/:service_id/' do
-    parameter :token, 'token', required: true
-    parameter :service_id, 'service ID', required: true
-
+  context 'HEAD /service_tokens/:token/:service_id/' do
     let(:token) { 'a_token' }
     let(:service_id) { 'a_service_id' }
 
     context 'when the (token, service_id) pair exists' do
       before { ThreeScale::Backend::ServiceToken.save(token, service_id) }
 
-      example_request 'Check if the pair exists' do
+      it 'Check if the pair exists' do
+        head "/service_tokens/#{token}/#{service_id}/"
+
         expect(status).to eq 200
       end
     end
@@ -28,13 +28,15 @@ resource 'Service Tokens (prefix: /service_tokens)' do
     context 'when the (token, service_id) pair does not exist' do
       before { ThreeScale::Backend::ServiceToken.delete(token, service_id) }
 
-      example_request 'Check if the pair exists' do
+      it 'Check if the pair exists' do
+        head "/service_tokens/#{token}/#{service_id}/"
+
         expect(status).to eq 404
       end
     end
   end
 
-  get '/service_tokens/:token/:service_id/provider_key' do
+  context 'GET /service_tokens/:token/:service_id/provider_key' do
     let(:token) { 'a_token' }
     let(:service_id) { 'a_service_id' }
 
@@ -46,8 +48,9 @@ resource 'Service Tokens (prefix: /service_tokens)' do
         ThreeScale::Backend::ServiceToken.save(token, service_id)
       end
 
-      example 'Get the provider key' do
-        do_request({ token: token, service_id: service_id })
+      it 'Get the provider key' do
+        get "/service_tokens/#{token}/#{service_id}/provider_key"
+
         expect(status).to eq 200
         expect(response_json['provider_key']).to eq provider_key
       end
@@ -56,153 +59,156 @@ resource 'Service Tokens (prefix: /service_tokens)' do
     context 'When the (token, service_id) pair does not exist' do
       before { ThreeScale::Backend::ServiceToken.delete(token, service_id) }
 
-      example 'Try to get the provider key' do
-        do_request({ token: token, service_id: service_id })
+      it 'Try to get the provider key' do
+        get "/service_tokens/#{token}/#{service_id}/provider_key"
+
         expect(status).to eq 404
         expect(response_json['error']).to eq 'token/service combination not found'
       end
     end
   end
 
-  post '/service_tokens/' do
-    parameter :service_tokens, 'Service Tokens', required: true
+  context '/service_tokens/' do
+    context 'POST' do
+      let(:service_token) { 'a_token' }
+      let(:service_id) { 'a_service_id' }
 
-    let(:service_token) { 'a_token' }
-    let(:service_id) { 'a_service_id' }
+      let(:service_tokens) do
+        { service_token => { service_id: service_id },
+          service_token.succ => { service_id: service_id } }
+      end
 
-    let(:service_tokens) do
-      { service_token => { service_id: service_id },
-        service_token.succ => { service_id: service_id } }
-    end
+      let(:invalid_service_token_error) do
+        exc = ThreeScale::Backend::ServiceToken::InvalidServiceToken.new
+        { http_code: exc.http_code, message: exc.message }
+      end
 
-    let(:invalid_service_token_error) do
-      exc = ThreeScale::Backend::ServiceToken::InvalidServiceToken.new
-      { http_code: exc.http_code, message: exc.message }
-    end
+      let(:invalid_service_id_error) do
+        exc = ThreeScale::Backend::ServiceToken::InvalidServiceId.new
+        { http_code: exc.http_code, message: exc.message }
+      end
 
-    let(:invalid_service_id_error) do
-      exc = ThreeScale::Backend::ServiceToken::InvalidServiceId.new
-      { http_code: exc.http_code, message: exc.message }
-    end
+      it 'Create a (service_token, service_id) pair' do
+        post '/service_tokens/', { service_tokens: }.to_json
 
-    let(:raw_post) { params.to_json }
+        expect(status).to eq 201
+        expect(response_json['status']).to eq 'created'
 
-    example_request 'Create a (service_token, service_id) pair' do
-      expect(status).to eq 201
-      expect(response_json['status']).to eq 'created'
-
-      service_tokens.each do |token, token_info|
-        expect(ThreeScale::Backend::ServiceToken.exists?(token, token_info[:service_id]))
+        service_tokens.each do |token, token_info|
+          expect(ThreeScale::Backend::ServiceToken.exists?(token, token_info[:service_id]))
             .to be true
+        end
       end
-    end
 
-    example 'Try to create a (service_token, service_id) pair with null service_token' do
-      do_request(service_tokens: { nil => { service_id: service_id } })
+      example 'Try to create a (service_token, service_id) pair with null service_token' do
+        post '/service_tokens/', { service_tokens: { nil => { service_id: service_id } } }.to_json
 
-      expect(status).to eq invalid_service_token_error[:http_code]
-      expect(response_json['error']).to eq invalid_service_token_error[:message]
-    end
+        expect(status).to eq invalid_service_token_error[:http_code]
+        expect(response_json['error']).to eq invalid_service_token_error[:message]
+      end
 
-    example 'Try to create a (service_token, service_id) pair with empty service_token' do
-      do_request(service_tokens: { '' => { service_id: service_id } })
+      example 'Try to create a (service_token, service_id) pair with empty service_token' do
+        post '/service_tokens/', { service_tokens: { '' => { service_id: service_id } } }.to_json
 
-      expect(status).to eq invalid_service_token_error[:http_code]
-      expect(response_json['error']).to eq invalid_service_token_error[:message]
-    end
+        expect(status).to eq invalid_service_token_error[:http_code]
+        expect(response_json['error']).to eq invalid_service_token_error[:message]
+      end
 
-    example 'Try to create a (service_token, service_id) pair with null service_id' do
-      do_request(service_tokens: { service_token => { service_id: nil } })
+      example 'Try to create a (service_token, service_id) pair with null service_id' do
+        post '/service_tokens/', { service_tokens: { service_token => { service_id: nil } } }.to_json
 
-      expect(status).to eq invalid_service_id_error[:http_code]
-      expect(response_json['error']).to eq invalid_service_id_error[:message]
-    end
+        expect(status).to eq invalid_service_id_error[:http_code]
+        expect(response_json['error']).to eq invalid_service_id_error[:message]
+      end
 
-    example 'Try to create a (service_token, service_id) pair with empty service_id' do
-      do_request(service_tokens: { service_token => { service_id: '' } })
+      example 'Try to create a (service_token, service_id) pair with empty service_id' do
+        post '/service_tokens/', { service_tokens: { service_token => { service_id: '' } } }.to_json
 
-      expect(status).to eq invalid_service_id_error[:http_code]
-      expect(response_json['error']).to eq invalid_service_id_error[:message]
-    end
+        expect(status).to eq invalid_service_id_error[:http_code]
+        expect(response_json['error']).to eq invalid_service_id_error[:message]
+      end
 
-    example 'Try to create a (service_token, service_id) without sending service_tokens' do
-      do_request(service_tokens: nil)
+      example 'Try to create a (service_token, service_id) without sending service_tokens' do
+        post '/service_tokens/'
 
-      expect(status).to eq 400
-      expect(response_json['error']).to eq "missing parameter 'service_tokens'"
-    end
+        expect(status).to eq 400
+        expect(response_json['error']).to eq "missing parameter 'service_tokens'"
+      end
 
-    example 'Try to create (service_token, service_id) pairs including one with invalid ID' do
-      tokens = service_tokens.merge({ 'valid_token' => { service_id: '' } })
-      do_request(service_tokens: tokens)
+      example 'Try to create (service_token, service_id) pairs including one with invalid ID' do
+        tokens = service_tokens.merge({ 'valid_token' => { service_id: '' } })
 
-      expect(status).to eq invalid_service_id_error[:http_code]
-      expect(response_json['error']).to eq invalid_service_id_error[:message]
+        post '/service_tokens/', { service_tokens: tokens }.to_json
 
-      tokens.each do |token, token_info|
-        expect(ThreeScale::Backend::ServiceToken.exists?(token, token_info[:service_id]))
+        expect(status).to eq invalid_service_id_error[:http_code]
+        expect(response_json['error']).to eq invalid_service_id_error[:message]
+
+        tokens.each do |token, token_info|
+          expect(ThreeScale::Backend::ServiceToken.exists?(token, token_info[:service_id]))
             .to be false
+        end
       end
-    end
 
-    example 'Try to create (service_token, service_id) pairs including one with invalid token' do
-      tokens = service_tokens.merge({ '' => { service_id: service_id } })
-      do_request(service_tokens: tokens)
+      example 'Try to create (service_token, service_id) pairs including one with invalid token' do
+        tokens = service_tokens.merge({ '' => { service_id: service_id } })
 
-      expect(status).to eq invalid_service_token_error[:http_code]
-      expect(response_json['error']).to eq invalid_service_token_error[:message]
+        post '/service_tokens/', { service_tokens: tokens }.to_json
 
-      tokens.each do |token, token_info|
-        expect(ThreeScale::Backend::ServiceToken.exists?(token, token_info[:service_id]))
+        expect(status).to eq invalid_service_token_error[:http_code]
+        expect(response_json['error']).to eq invalid_service_token_error[:message]
+
+        tokens.each do |token, token_info|
+          expect(ThreeScale::Backend::ServiceToken.exists?(token, token_info[:service_id]))
             .to be false
-      end
-    end
-  end
-
-  delete '/service_tokens/' do
-    parameter :service_tokens, 'Service token', required: true
-
-    let(:existing_tokens) do
-      [{ service_token: 'token1', service_id: 'id1' },
-       { service_token: 'token2', service_id: 'id2' }]
-    end
-
-    let(:non_existing_tokens) do
-      [{ service_token: 'token3', service_id: 'id3' }]
-    end
-
-    let(:service_tokens) { existing_tokens + non_existing_tokens }
-
-    before do
-      existing_tokens.each do |token|
-        ThreeScale::Backend::ServiceToken.save(token[:service_token], token[:service_id])
+        end
       end
     end
 
-    example_request 'Delete a list of (service_token, service_id) pairs' do
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'deleted'
-      expect(response_json['count']).to eq existing_tokens.size
+    context 'DELETE' do
+      let(:existing_tokens) do
+        [{ service_token: 'token1', service_id: 'id1' },
+         { service_token: 'token2', service_id: 'id2' }]
+      end
 
-      existing_tokens.each do |token|
-        expect(ThreeScale::Backend::ServiceToken.exists?(
+      let(:non_existing_tokens) do
+        [{ service_token: 'token3', service_id: 'id3' }]
+      end
+
+      let(:service_tokens) { existing_tokens + non_existing_tokens }
+
+      before do
+        existing_tokens.each do |token|
+          ThreeScale::Backend::ServiceToken.save(token[:service_token], token[:service_id])
+        end
+      end
+
+      it 'Delete a list of (service_token, service_id) pairs' do
+        delete '/service_tokens/', { service_tokens: }.to_json
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'deleted'
+        expect(response_json['count']).to eq existing_tokens.size
+
+        existing_tokens.each do |token|
+          expect(ThreeScale::Backend::ServiceToken.exists?(
             token[:service_token], token[:service_id])).to be false
+        end
       end
-    end
 
-    example 'Try to delete list of (service_token, service_id) without sending service_tokens' do
-      do_request(service_tokens: nil)
+      it 'Try to delete list of (service_token, service_id) without sending service_tokens' do
+        delete '/service_tokens/'
 
-      expect(status).to eq 400
-      expect(response_json['error']).to eq "missing parameter 'service_tokens'"
-    end
+        expect(status).to eq 400
+        expect(response_json['error']).to eq "missing parameter 'service_tokens'"
+      end
 
-    example 'Try to delete a list of (service_token, service_id) that does not exist' do
-      do_request(service_tokens: non_existing_tokens)
+      example 'Try to delete a list of (service_token, service_id) that does not exist' do
+        delete '/service_tokens/', { service_tokens: non_existing_tokens }.to_json
 
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'deleted'
-      expect(response_json['count']).to be_zero
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'deleted'
+        expect(response_json['count']).to be_zero
+      end
     end
   end
 end

--- a/spec/acceptance/api/internal/services_api_spec.rb
+++ b/spec/acceptance/api/internal/services_api_spec.rb
@@ -1,6 +1,4 @@
-resource 'Services (prefix: /services)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
+describe 'Services (prefix: /services)' do
 
   let(:someid) { '1001' }
   let(:otherid) { '2001' }
@@ -9,77 +7,193 @@ resource 'Services (prefix: /services)' do
   let(:state) { :active }
 
   before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+
     ThreeScale::Backend::Service.save!(provider_key: provider_key, id: someid)
     ThreeScale::Backend::Service.save!(provider_key: provider_key, id: otherid, state: state)
   end
 
-  get '/services/:id' do
-    parameter :id, 'Service ID', required: true
+  context '/services/:id' do
+    context 'GET' do
+      let(:id) { someid }
 
-    let(:id) { someid }
+      it 'Get Service by ID' do
+        get "/services/#{id}"
 
-    example_request 'Get Service by ID' do
-      expect(response_json['service']['id']).to eq id
-      expect(response_json['service']['provider_key']).to eq provider_key
-      expect(status).to eq 200
-    end
+        expect(response_json['service']['id']).to eq id
+        expect(response_json['service']['provider_key']).to eq provider_key
+        expect(status).to eq 200
+      end
 
-    example 'Try to get a Service by non-existent ID' do
-      do_request(id: invalid_id)
-      expect(status).to eq 404
-      expect(response_json['error']).to match /not_found/
-    end
+      it 'Try to get a Service by non-existent ID' do
+        get "/services/#{invalid_id}"
 
-    describe 'Get service and check state' do
-      context 'when state is not set' do
-        let(:id) { someid }
-        example_request 'Get Service by ID' do
-          expect(status).to eq 200
-          expect(response_json['service']['id']).to eq id
-          expect(response_json['service']['state']).to eq 'active'
+        expect(status).to eq 404
+        expect(response_json['error']).to match /not_found/
+      end
+
+      describe 'Get service and check state' do
+        context 'when state is not set' do
+          let(:id) { someid }
+          it 'Get Service by ID' do
+            get "/services/#{id}"
+
+            expect(status).to eq 200
+            expect(response_json['service']['id']).to eq id
+            expect(response_json['service']['state']).to eq 'active'
+          end
+        end
+        context 'when state is active' do
+          let(:id) { otherid }
+          it 'Get Service by ID' do
+            get "/services/#{id}"
+
+            expect(status).to eq 200
+            expect(response_json['service']['id']).to eq id
+            expect(response_json['service']['state']).to eq 'active'
+          end
+        end
+        context 'when state is set to nil' do
+          let(:id) { otherid }
+          let(:state) { nil }
+          it 'Get Service by ID' do
+            get "/services/#{id}"
+
+            expect(status).to eq 200
+            expect(response_json['service']['id']).to eq id
+            expect(response_json['service']['state']).to eq 'active'
+          end
+        end
+        context 'when state is suspended' do
+          let(:state) { :suspended }
+          let(:id) { otherid }
+          it 'Get Service by ID' do
+            get "/services/#{id}"
+
+            expect(status).to eq 200
+            expect(response_json['service']['id']).to eq id
+            expect(response_json['service']['state']).to eq state.to_s
+          end
+        end
+        context 'when state is set to an invalid state' do
+          let(:state) { :not_valid_state }
+          let(:id) { otherid }
+          it 'Get Service by ID' do
+            get "/services/#{id}"
+
+            expect(status).to eq 200
+            expect(response_json['service']['id']).to eq id
+            expect(response_json['service']['state']).to eq 'suspended'
+          end
         end
       end
-      context 'when state is active' do
-        let(:id) { otherid }
-        example_request 'Get Service by ID' do
-          expect(status).to eq 200
-          expect(response_json['service']['id']).to eq id
-          expect(response_json['service']['state']).to eq 'active'
-        end
+    end
+
+    context 'PUT' do
+      let(:id){ 1001 }
+      let(:state) { :active }
+      let(:service) do
+        {
+          provider_key: 'foo',
+          referrer_filters_required: true,
+          backend_version: 'oauth',
+          default_service: true,
+          state: state
+        }
       end
-      context 'when state is set to nil' do
-        let(:id) { otherid }
+
+      it 'Update Service by ID' do
+        put "/services/#{id}", { service: }.to_json
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'ok'
+
+        svc = ThreeScale::Backend::Service.load_by_id('1001')
+        expect(svc.to_hash).to eq service.merge(id: '1001')
+      end
+
+      it 'Update Service by ID using extra params that should be ignored' do
+        put "/services/#{id}", {service: service.merge(some_param: 'some_value')}.to_json
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'ok'
+
+        svc = ThreeScale::Backend::Service.load_by_id('1001')
+        expect(svc).not_to be_nil
+        expect(svc).not_to respond_to :some_param
+        # The returned data should not contain *some_param* attribute
+        expect(svc.to_hash).to eq service.merge(id: '1001')
+      end
+
+      context 'Create a service that has no state' do
         let(:state) { nil }
-        example_request 'Get Service by ID' do
+
+        it 'creating the service returns an active service' do
+          put "/services/#{id}", { service: }.to_json
+
           expect(status).to eq 200
-          expect(response_json['service']['id']).to eq id
-          expect(response_json['service']['state']).to eq 'active'
+          expect(response_json['status']).to eq 'ok'
+
+          svc = ThreeScale::Backend::Service.load_by_id('1001')
+          expect(svc.active?).to be_truthy
         end
       end
-      context 'when state is suspended' do
-        let(:state) { :suspended }
-        let(:id) { otherid }
-        example_request 'Get Service by ID' do
+
+      context 'Create a Service with invalid state' do
+        let(:state) { :invalid_state }
+
+        it 'returns inactive service' do
+          put "/services/#{id}", { service: }.to_json
+
           expect(status).to eq 200
-          expect(response_json['service']['id']).to eq id
-          expect(response_json['service']['state']).to eq state.to_s
+          svc = ThreeScale::Backend::Service.load_by_id('1001')
+          expect(svc).not_to be_nil
+          expect(svc.active?).to be_falsy
         end
       end
-      context 'when state is set to an invalid state' do
-        let(:state) { :not_valid_state }
-        let(:id) { otherid }
-        example_request 'Get Service by ID' do
-          expect(status).to eq 200
-          expect(response_json['service']['id']).to eq id
-          expect(response_json['service']['state']).to eq 'suspended'
+    end
+
+    context 'DELETE' do
+      let(:default_service_id) { '1' }
+      let(:non_default_service_id) { '2' }
+
+      before { ThreeScale::Backend::Storage.instance.flushdb }
+
+      it 'Deleting a default service when there are more' do
+        [default_service_id, non_default_service_id].each do |id|
+          ThreeScale::Backend::Service.save!(provider_key: provider_key, id: id)
         end
+
+        delete "/services/#{default_service_id}"
+
+        expect(status).to eq 400
+        expect(response_json['error']).to match /cannot be removed/
+      end
+
+      it 'Deleting a default service when it is the only one' do
+        ThreeScale::Backend::Service.save!(provider_key: provider_key, id: default_service_id)
+
+        delete "/services/#{default_service_id}"
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'deleted'
+      end
+
+      it 'Deleting a non-default service' do
+        [default_service_id, non_default_service_id].each do |id|
+          ThreeScale::Backend::Service.save!(provider_key: provider_key, id: id)
+        end
+
+        delete "/services/#{non_default_service_id}"
+
+        expect(status).to eq 200
+        expect(response_json['status']).to eq 'deleted'
       end
     end
   end
 
-  post '/services/' do
-    parameter :service, 'Service attributes', required: true
-
+  context 'POST /services/' do
     let(:state) { :active }
     let(:service) do
       {
@@ -91,9 +205,10 @@ resource 'Services (prefix: /services)' do
         state: state
       }
     end
-    let(:raw_post){ params.to_json }
 
-    example_request 'Create a Service' do
+    it 'Create a Service' do
+      post '/services/', { service: }.to_json
+
       expect(status).to eq 201
       expect(response_json['status']).to eq 'created'
 
@@ -101,15 +216,16 @@ resource 'Services (prefix: /services)' do
       expect(svc.to_hash).to eq service
     end
 
-    example 'Try creating a Service without specifying the service parameter in the body' do
-      do_request(service: nil)
+    it 'Try creating a Service without specifying the service parameter in the body' do
+      post '/services/'
 
       expect(status).to eq 400
       expect(response_json['error']).to match /missing parameter 'service'/
     end
 
-    example 'Create a Service with extra params that should be ignored' do
-      do_request service: service.merge(some_param: 'some_value')
+    it 'Create a Service with extra params that should be ignored' do
+      post '/services/', { service: service.merge(some_param: 'some_value') }.to_json
+
       expect(status).to eq 201
       expect(response_json['status']).to eq 'created'
 
@@ -123,7 +239,9 @@ resource 'Services (prefix: /services)' do
     context 'with an service that has no state' do
       let(:state) { nil }
 
-      example_request 'creating the service returns an active service' do
+      it 'creating the service returns an active service' do
+        post '/services/', { service: }.to_json
+
         expect(status).to eq 201
         expect(response_json['status']).to eq 'created'
 
@@ -136,7 +254,9 @@ resource 'Services (prefix: /services)' do
     context 'Create a Service with invalid state' do
       let(:state) { :invalid_state }
 
-      example_request 'returns inactive service' do
+      it 'returns inactive service' do
+        post '/services/', { service: }.to_json
+
         expect(status).to eq 201
         svc = ThreeScale::Backend::Service.load_by_id('1002')
         expect(svc).not_to be_nil
@@ -145,137 +265,38 @@ resource 'Services (prefix: /services)' do
     end
   end
 
-  put '/services/:id' do
-    parameter :id, 'Service ID', required: true
-    parameter :service, 'Service attributes', required: true
-
-    let(:id){ 1001 }
-    let(:state) { :active }
-    let(:service) do
-      {
-        provider_key: 'foo',
-        referrer_filters_required: true,
-        backend_version: 'oauth',
-        default_service: true,
-        state: state
-      }
-    end
-    let(:raw_post){ params.to_json }
-
-    example_request 'Update Service by ID' do
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'ok'
-
-      svc = ThreeScale::Backend::Service.load_by_id('1001')
-      expect(svc.to_hash).to eq service.merge(id: '1001')
-    end
-
-    example 'Update Service by ID using extra params that should be ignored' do
-      do_request service: service.merge(some_param: 'some_value')
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'ok'
-
-      svc = ThreeScale::Backend::Service.load_by_id('1001')
-      expect(svc).not_to be_nil
-      expect(svc).not_to respond_to :some_param
-      # The returned data should not contain *some_param* attribute
-      expect(svc.to_hash).to eq service.merge(id: '1001')
-    end
-
-    context 'Create a service that has no state' do
-      let(:state) { nil }
-
-      example_request 'creating the service returns an active service' do
-        expect(status).to eq 200
-        expect(response_json['status']).to eq 'ok'
-
-        svc = ThreeScale::Backend::Service.load_by_id('1001')
-        expect(svc.active?).to be_truthy
-      end
-    end
-
-    context 'Create a Service with invalid state' do
-      let(:state) { :invalid_state }
-
-      example_request 'returns inactive service' do
-        expect(status).to eq 200
-        svc = ThreeScale::Backend::Service.load_by_id('1001')
-        expect(svc).not_to be_nil
-        expect(svc.active?).to be_falsy
-      end
-    end
-  end
-
-  put '/services/change_provider_key/:key' do
-    parameter :key, 'Existing provider key', required: true
-    parameter :new_key, 'New provider key', required: true
-
+  context 'PUT /services/change_provider_key/:key' do
     let(:key){ 'foo' }
     let(:new_key){ 'bar' }
-    let(:raw_post) { params.to_json }
 
-    example_request 'Changing a provider key'do
+    it 'Changing a provider key' do
+      put "/services/change_provider_key/#{key}", { new_key: }.to_json
+
       expect(status).to eq 200
       expect(response_json['status']).to eq 'ok'
     end
 
-    example_request 'Trying to change a provider key to empty', new_key: '' do
+    it 'Trying to change a provider key to empty' do
+      put "/services/change_provider_key/#{key}"
+
       expect(status).to eq 400
       expect(response_json['error']).to match /keys are not valid/
     end
 
-    example 'Trying to change a provider key to an existing one' do
+    it 'Trying to change a provider key to an existing one' do
       ThreeScale::Backend::Service.save! id: 7002, provider_key: 'bar'
-      do_request new_key: 'bar'
+
+      put "/services/change_provider_key/#{key}", { new_key: }.to_json
 
       expect(status).to eq 400
       expect(response_json['error']).to match /already exists/
     end
 
-    example_request 'Trying to change a non-existent provider key', key: 'baz' do
+    it 'Trying to change a non-existent provider key' do
+      put "/services/change_provider_key/baz", { new_key: }.to_json
+
       expect(status).to eq 400
       expect(response_json['error']).to match /does not exist/
-    end
-  end
-
-  delete '/services/:id' do
-    parameter :id, 'Service ID', required: true
-
-    let(:raw_post) { params.to_json }
-    let(:default_service_id) { '1' }
-    let(:non_default_service_id) { '2' }
-
-    before { ThreeScale::Backend::Storage.instance.flushdb }
-
-    example 'Deleting a default service when there are more' do
-      [default_service_id, non_default_service_id].each do |id|
-        ThreeScale::Backend::Service.save!(provider_key: provider_key, id: id)
-      end
-
-      do_request id: default_service_id
-
-      expect(status).to eq 400
-      expect(response_json['error']).to match /cannot be removed/
-    end
-
-    example 'Deleting a default service when it is the only one' do
-      ThreeScale::Backend::Service.save!(provider_key: provider_key, id: default_service_id)
-
-      do_request id: default_service_id
-
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'deleted'
-    end
-
-    example 'Deleting a non-default service' do
-      [default_service_id, non_default_service_id].each do |id|
-        ThreeScale::Backend::Service.save!(provider_key: provider_key, id: id)
-      end
-
-      do_request id: non_default_service_id
-
-      expect(status).to eq 200
-      expect(response_json['status']).to eq 'deleted'
     end
   end
 end

--- a/spec/acceptance/api/internal/stats_api_spec.rb
+++ b/spec/acceptance/api/internal/stats_api_spec.rb
@@ -1,7 +1,4 @@
-resource 'Stats (prefix: /services/:service_id/stats)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
-
+describe 'Stats (prefix: /services/:service_id/stats)' do
   let(:existing_service_id) { '10000' }
   let(:service_id) { existing_service_id }
   let(:provider_key) { 'statsfoo' }
@@ -19,22 +16,23 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
       }
     }.to_json
   end
-  # From and To fields are sent as string, even though they are integers in req_body
-  let(:raw_post) { req_body }
 
   before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
     ThreeScale::Backend::Service.save!(provider_key: provider_key, id: existing_service_id)
   end
 
-  delete '/services/:service_id/stats' do
-    parameter :service_id, 'Service ID', required: true
+  context 'DELETE /services/:service_id/stats' do
 
     context 'PartitionGeneratorJob is enqueued' do
       before do
         ResqueSpec.reset!
       end
 
-      example_request 'Deleting stats' do
+      it 'Deleting stats' do
+        delete "/services/#{service_id}/stats"
+
         expect(status).to eq 200
         expect(response_json['status']).to eq 'to_be_deleted'
       end
@@ -43,7 +41,9 @@ resource 'Stats (prefix: /services/:service_id/stats)' do
     context 'service does not exist' do
       let(:service_id) { existing_service_id + 'foo' }
 
-      example_request 'Deleting stats' do
+      it 'Deleting stats' do
+        delete "/services/#{service_id}/stats"
+
         expect(status).to eq 404
       end
     end

--- a/spec/acceptance/api/internal/usagelimits_api_spec.rb
+++ b/spec/acceptance/api/internal/usagelimits_api_spec.rb
@@ -1,11 +1,12 @@
-resource 'UsageLimits (prefix: /services/:service_id/plans/:plan_id/usagelimits)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
+describe 'UsageLimits (prefix: /services/:service_id/plans/:plan_id/usagelimits)' do
 
   let(:service_id) { '7575' }
   let(:plan_id) { '100' }
 
   before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+
     ThreeScale::Backend::Metric.delete(service_id, '100')
     ThreeScale::Backend::Metric.delete(service_id, '101')
     metric = ThreeScale::Backend::Metric.save(service_id: service_id, id: '100',
@@ -19,16 +20,13 @@ resource 'UsageLimits (prefix: /services/:service_id/plans/:plan_id/usagelimits)
     end
   end
 
-  get '/services/:service_id/plans/:plan_id/usagelimits/:metric_id/:period' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :plan_id, 'Plan ID', required: true
-    parameter :metric_id, 'Metric ID', required: true
-    parameter :period, 'Period', required: true
+  context '/services/:service_id/plans/:plan_id/usagelimits/:metric_id/:period' do
 
-    example 'Get UsageLimits' do
+    it 'Get UsageLimits' do
       @metric_h.each do |m, periods|
         periods.each do |period, value|
-          do_request metric_id: m.id, period: period
+          get "/services/#{service_id}/plans/#{plan_id}/usagelimits/#{m.id}/#{period}"
+
           expect(response_json['usagelimit']['service_id']).to eq service_id
           expect(response_json['usagelimit']['plan_id']).to eq plan_id
           expect(response_json['usagelimit']['metric_id']).to eq m.id
@@ -37,24 +35,12 @@ resource 'UsageLimits (prefix: /services/:service_id/plans/:plan_id/usagelimits)
         end
       end
     end
-  end
 
-  put '/services/:service_id/plans/:plan_id/usagelimits/:metric_id/:period' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :plan_id, 'Plan ID', required: true
-    parameter :metric_id, 'Metric ID', required: true
-    parameter :period, 'Period', required: true
-    parameter :usagelimit, 'UsageLimit attributes', required: true
-
-    # need this to _not_ be memoized but eval'ed each time, see below
-    define_method :raw_post do
-      params.to_json
-    end
-
-    example 'Update UsageLimits' do
+    it 'Update UsageLimits' do
       @metric_h.each do |m, periods|
         periods.each do |p, value|
-          do_request(metric_id: m.id, period: p, usagelimit: { p.to_sym => value.succ.to_s })
+          put "/services/#{service_id}/plans/#{plan_id}/usagelimits/#{m.id}/#{p}", { usagelimit: { p.to_sym => value.succ.to_s } }.to_json
+
           expect(response_json['usagelimit']['service_id']).to eq service_id
           expect(response_json['usagelimit']['plan_id']).to eq plan_id
           expect(response_json['usagelimit']['metric_id']).to eq m.id
@@ -67,18 +53,12 @@ resource 'UsageLimits (prefix: /services/:service_id/plans/:plan_id/usagelimits)
         end
       end
     end
-  end
 
-  delete '/services/:service_id/plans/:plan_id/usagelimits/:metric_id/:period' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :plan_id, 'Plan ID', required: true
-    parameter :metric_id, 'Metric ID', required: true
-    parameter :period, 'Period', required: true
-
-    example 'Delete UsageLimits' do
+    it 'Delete UsageLimits' do
       @metric_h.each do |m, periods|
         periods.each do |period, value|
-          do_request metric_id: m.id, period: period
+          delete "/services/#{service_id}/plans/#{plan_id}/usagelimits/#{m.id}/#{period}"
+
           expect(response_json['status']).to eq 'deleted'
           expect(status).to eq 200
 

--- a/spec/acceptance/api/internal/utilization_api_spec.rb
+++ b/spec/acceptance/api/internal/utilization_api_spec.rb
@@ -1,7 +1,4 @@
-resource 'Utilization (prefix: /services/:service_id/applications/:app_id/utilization)' do
-  header 'Accept', 'application/json'
-  header 'Content-Type', 'application/json'
-
+describe 'Utilization (prefix: /services/:service_id/applications/:app_id/utilization)' do
   # Service IDs
   let(:service_id) { '1111' }
   let(:non_existing_service_id) { service_id.to_i.succ.to_s }
@@ -80,6 +77,9 @@ resource 'Utilization (prefix: /services/:service_id/applications/:app_id/utiliz
   end
 
   before do
+    header 'Accept', 'application/json'
+    header 'Content-Type', 'application/json'
+
     ThreeScale::Backend::Service.save!(provider_key: provider_key,
                                        id: service_id)
 
@@ -99,10 +99,7 @@ resource 'Utilization (prefix: /services/:service_id/applications/:app_id/utiliz
     expect(actual_report['current_value']).to eq(expected_report[:current_value])
   end
 
-  get '/services/:service_id/applications/:app_id/utilization/' do
-    parameter :service_id, 'Service ID', required: true
-    parameter :app_id, 'Application ID', required: true
-
+  context 'GET /services/:service_id/applications/:app_id/utilization/' do
     context 'with application with limited plan' do
       let(:hits_transaction_1) { 50 }
       let(:hits_transaction_2) { 30 }
@@ -128,7 +125,9 @@ resource 'Utilization (prefix: /services/:service_id/applications/:app_id/utiliz
         end
       end
 
-      example_request 'Get utilization' do
+      it 'Get utilization' do
+        get "/services/#{service_id}/applications/#{app_id}/utilization/"
+
         utilization = response_json['utilization']
         expect(utilization.size).to eq(test_usage_limits.size)
 
@@ -155,16 +154,18 @@ resource 'Utilization (prefix: /services/:service_id/applications/:app_id/utiliz
     end
 
     context 'with application with unlimited plan' do
-      example 'Get utilization' do
-        do_request(app_id: unlimited_app_id)
+      it 'Get utilization' do
+        get "/services/#{service_id}/applications/#{unlimited_app_id}/utilization/"
+
         expect(response_json['utilization']).to be_empty
         expect(response_status).to eq(200)
       end
     end
 
     context 'with application with zero limits plan' do
-      example 'Get utilization' do
-        do_request(app_id: zero_limits_app_id)
+      it 'Get utilization' do
+        get "/services/#{service_id}/applications/#{zero_limits_app_id}/utilization/"
+
         utilization = response_json['utilization']
 
         expect(utilization.size).to eq(usage_limits_with_zeros.size)
@@ -179,15 +180,17 @@ resource 'Utilization (prefix: /services/:service_id/applications/:app_id/utiliz
     end
 
     context 'with non-existing service ID' do
-      example 'Try to get utilization' do
-        do_request(service_id: non_existing_service_id)
+      it 'Try to get utilization' do
+        get "/services/#{non_existing_service_id}/applications/#{app_id}/utilization/"
+
         expect(response_status).to eq(404)
       end
     end
 
     context 'with non-existing app ID' do
-      example 'Try to get utilization' do
-        do_request(app_id: non_existing_app_id)
+      it 'Try to get utilization' do
+        get "/services/#{service_id}/applications/#{non_existing_app_id}/utilization/"
+
         expect(response_status).to eq(404)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,8 @@ require 'rspec'
 require 'resque_spec'
 require 'async'
 
-# This fixes a `NoMethodError` error caused by `rspec_api_documentation`, which is fixed since 2022, but never released.
-# Ref: https://github.com/zipmark/rspec_api_documentation/commit/758c879893a21233c0eb977e79ef026f263fc37e
+require 'active_support'
+require 'active_support/core_ext/object/json'
 require 'active_support/core_ext/hash/keys'
 
 if ENV['TEST_COVERAGE']

--- a/spec/spec_helpers/acceptance_spec_helper.rb
+++ b/spec/spec_helpers/acceptance_spec_helper.rb
@@ -1,18 +1,20 @@
 require_relative '../../app/api/api'
 
 require 'rack/test'
-require 'rspec_api_documentation'
-require 'rspec_api_documentation/dsl'
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
 end
 
-RspecApiDocumentation.configure do |config|
-  config.docs_dir = Pathname.new(__FILE__).dirname.join('..', '..', 'docs', 'internal_api')
-  config.app = ThreeScale::Backend::API::Internal.new(allow_insecure: true)
+def response_json
+  JSON.parse(last_response.body)
 end
 
-def response_json
-  JSON.parse(response_body)
+def status
+  last_response.status
+end
+alias :response_status :status
+
+def app
+  ThreeScale::Backend::API::Internal.new(allow_insecure: true)
 end


### PR DESCRIPTION
**Description**:

This removes the `rspec_api_documentation` gem. It's used to generate some documentation for the backend API from a few tests suites written using a particular DSL.

I'm not sure where is this documentation used/published/needed... I never heard of it before. The gem is a problem because it's abandoned and can't be updated. Check the description in https://github.com/3scale/apisonator/pull/411

**Issue**:

https://issues.redhat.com/browse/THREESCALE-11536

**Notes for reviewers**:

This PR consists on removing the gem and migration the affected test suites to the regular rspec syntax, basically:

- move `header` calls to inside a `before` callback
- replace `resource` by `describe`
- replace `example` and `example_request` by `it`
- Launch the requests directly through method names (`get`, `post`, etc), instead of calling `do_request` (under `example`) or making the call implicit (under `example_request`)
- remove calls to `parameter`, they were intended for documentation purposes and to generate the request from inside `example_request`. Not needed in  regular rspec.

