### PR TITLE
Upgrade GLI to remove warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ end
 # Default server by platform
 gem 'puma', '~> 6.5.0'
 # gems required by the runner
-gem 'gli', '~> 2.16.1', require: nil
+gem 'gli', '~> 2.22.2', require: nil
 # Workers
 gem 'daemons', '= 1.2.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,8 @@ GEM
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.0)
-    gli (2.16.1)
+    gli (2.22.2)
+      ostruct
     google-protobuf (4.28.2)
       bigdecimal
       rake (>= 13)
@@ -158,6 +159,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
+    ostruct (0.6.1)
     pkg-config (1.1.9)
     power_assert (2.0.3)
     process-metrics (0.2.1)
@@ -305,7 +307,7 @@ DEPENDENCIES
   daemons (= 1.2.4)
   dotenv
   falcon (= 0.43)
-  gli (~> 2.16.1)
+  gli (~> 2.22.2)
   hiredis-client
   license_finder (~> 7.0)
   mocha (~> 1.3)


### PR DESCRIPTION
Removing the annoying warnings:

```
/opt/ruby/apisonator-3.4.3/vendor/bundle/ruby/3.3.0/gems/gli-2.16.1/lib/gli/commands/help_modules/global_help_format.rb:37: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/opt/ruby/apisonator-3.4.3/vendor/bundle/ruby/3.3.0/gems/gli-2.16.1/lib/gli/commands/help_modules/global_help_format.rb:37: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/opt/ruby/apisonator-3.4.3/vendor/bundle/ruby/3.3.0/gems/gli-2.16.1/lib/gli/commands/help_modules/command_help_format.rb:28: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/opt/ruby/apisonator-3.4.3/vendor/bundle/ruby/3.3.0/gems/gli-2.16.1/lib/gli/commands/help_modules/command_help_format.rb:28: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.

```

It's fixed in v2.20.0, but upgrading to the latest just in case: https://github.com/davetron5000/gli/issues/301#issuecomment-778691143