### PR TITLE
THREESCALE-9408: Valid XML response from `oauth_authorize.xml`

### DIFF
--- a/lib/3scale/backend/transactor/status.rb
+++ b/lib/3scale/backend/transactor/status.rb
@@ -202,7 +202,7 @@ module ThreeScale
         end
 
         def add_application_section(xml)
-          redirect_uri = application.redirect_url
+          redirect_uri = application.redirect_url&.encode(xml: :text)
           xml << '<application>' \
                  "<id>#{application.id}</id>" \
                  "<key>#{application.keys.first}</key>" \

--- a/test/unit/transactor/status_test.rb
+++ b/test/unit/transactor/status_test.rb
@@ -297,5 +297,21 @@ module Transactor
       assert_not_empty keys
       assert_equal @keys.sort, keys.sort
     end
+
+    test '#to_xml escapes application.redirect_url when OAuth is used' do
+      @application.redirect_url = 'http://example.com?foor=bar&test=true'
+      usage  = {:month => {@metric_id.to_s => 429}}
+      status = Transactor::Status.new(service_id: @service_id,
+                                      application: @application,
+                                      values: usage,
+                                      oauth: true)
+
+      doc = Nokogiri::XML(status.to_xml)
+      redirect_url = doc.at 'redirect_url'
+
+      # If redirect_url is present and the document is still valid is because escaping worked
+      assert_not_nil redirect_url
+      assert_empty doc.errors
+    end
   end
 end

--- a/test/unit/transactor/status_test.rb
+++ b/test/unit/transactor/status_test.rb
@@ -310,7 +310,7 @@ module Transactor
       redirect_url = doc.at 'redirect_url'
 
       # If redirect_url is present and the document is still valid is because escaping worked
-      assert_not_nil redirect_url
+      assert_equal @application.redirect_url, redirect_url.text
       assert_empty doc.errors
     end
   end


### PR DESCRIPTION
`oauth_authorize.xml` is returning an invalid XML when the `application` has a `redirect_url` containing some of the next characters:

```
"   &quot;
'   &apos;
<   &lt;
>   &gt;
&   &amp;
```

This PR escapes the `redirect_url` attribute to fix the issue.

**Jira Issue:**

https://issues.redhat.com/browse/THREESCALE-9408

**How to reproduce:**

From porta:

1. Go to Product -> Integration -> Settings
2. Set Authentication to `OpenID Connect`
3. Fill `OpenID Connect (OIDC) Basics` to a valid keycloak server (ask me if you don't have one)
4. Go to Applications -> Listing and pick one
5. Set Redirect URL to something including any of the characters above.
   1. e.g. `http://provider.3scale.localhost:3000?test=true&foo=bar`