### PR TITLE
THREESCALE-8964: Fix key credentials validation

### DIFF
--- a/lib/3scale/backend/errors.rb
+++ b/lib/3scale/backend/errors.rb
@@ -260,7 +260,11 @@ module ThreeScale
 
     class UserKeyInvalid < Error
       def initialize(key)
-        super %(user key "#{key}" is invalid)
+        if key.blank?
+          super 'user key is missing'.freeze
+        else
+          super %(user key "#{key}" is invalid)
+        end
       end
     end
 

--- a/lib/3scale/backend/transactor.rb
+++ b/lib/3scale/backend/transactor.rb
@@ -67,10 +67,10 @@ module ThreeScale
         service_id = service.id
 
         app_id = params[:app_id]
-        # TODO: make sure params are nil if they are empty up the call stack
+        # Make sure params are nil if they are empty up the call stack
         # Note: app_key is an exception, as it being empty is semantically
         # significant.
-        params[:app_id] = nil if app_id && app_id.empty?
+        params[:app_id] = nil if app_id&.empty?
 
         # While OIDC without an app_id makes little sense, we would break existing
         # behaviour when calling non oauth_auth*.xml endpoints if we returned an

--- a/lib/3scale/backend/validators/key.rb
+++ b/lib/3scale/backend/validators/key.rb
@@ -3,12 +3,18 @@ module ThreeScale
     module Validators
       class Key < Base
         def apply
-          if service.backend_version.to_i == 1 ||
-              application.has_no_keys? ||
-              application.has_key?(params[:app_key])
-            succeed!
-          else
+          case service.backend_version.to_i
+          when 1 # Auth by user_key
+            return succeed! if params.has_key?(:user_key)
+
+            fail!(UserKeyInvalid.new(params[:user_key]))
+          when 2, 0  # 2 -> Auth by app_id. 0 -> not defined or invalid, must behave like 2
+            return succeed! if params.has_key?(:app_id) && (application.has_no_keys? || application.has_key?(params[:app_key]))
+
             fail!(ApplicationKeyInvalid.new(params[:app_key]))
+          else
+            # This should never happen
+            fail!(Error.new("Invalid backend version: #{service.backend_version.to_i}"))
           end
         end
       end

--- a/spec/server/listener_metrics_spec.rb
+++ b/spec/server/listener_metrics_spec.rb
@@ -12,6 +12,7 @@ module ThreeScale
       let(:metrics_port) { 9394 }
 
       context 'when listener metrics are enabled' do
+        let(:backend_version) { '1' }
         let(:provider_key) { 'pk' }
         let(:service_id) { '1' }
         let(:app_id) { '1' }
@@ -39,7 +40,7 @@ module ThreeScale
             start_listener(true, LISTENER_PORT, metrics_port, server)
 
             ThreeScale::Backend::Service.save!(
-              provider_key: provider_key, id: service_id
+              provider_key: provider_key, id: service_id, backend_version: backend_version
             )
 
             ThreeScale::Backend::Application.save(

--- a/test/integration/authorize/legacy_test.rb
+++ b/test/integration/authorize/legacy_test.rb
@@ -11,6 +11,8 @@ class AuthorizeLegacyTest < Test::Unit::TestCase
 
     setup_provider_fixtures
 
+    Service.save! id: @service.id, provider_key: @provider_key, backend_version: '1'
+
     @application = Application.save(:service_id => @service.id,
                                     :id         => next_id,
                                     :state      => :active,

--- a/test/integration/backend_version_test.rb
+++ b/test/integration/backend_version_test.rb
@@ -20,13 +20,13 @@ class BackendVersionTest < Test::Unit::TestCase
     Application.save_id_by_key(@service_id, "user_key_#{@application.id}", @application.id)
   end
 
-  test 'test app_id and user_key are exchangeable regardless of the backend_version' do
+  test 'test app_id and user_key are not exchangeable regardless and are bound to the backend_version' do
     Service.save! id: @service.id, provider_key: @provider_key, backend_version: '1'
 
     get '/transactions/authorize.xml', :provider_key => @provider_key,
                                        :app_id       => @application.id
 
-    assert_authorized
+    assert_not_authorized
 
     get '/transactions/authorize.xml', :provider_key => @provider_key,
                                        :user_key     => "user_key_#{@application.id}"
@@ -43,7 +43,7 @@ class BackendVersionTest < Test::Unit::TestCase
     get '/transactions/authorize.xml', :provider_key => @provider_key,
                                        :user_key     => "user_key_#{@application.id}"
 
-    assert_authorized
+    assert_not_authorized
   end
 
   test 'service originally on backend_version 2 with apps with app_key does not complain about missing app_key when changed to backend_version 1' do
@@ -83,7 +83,6 @@ class BackendVersionTest < Test::Unit::TestCase
   test 'when backend_version is not declared should behave like backend_version two regarding the presence of app_key' do
     if @service.backend_version.nil? || @service.backend_version.empty?
       application_key_one = @application.create_key
-      _application_key_two = @application.create_key
 
       get '/transactions/authorize.xml', :provider_key => @provider_key,
                                        :app_id       => @application.id,
@@ -102,7 +101,6 @@ class BackendVersionTest < Test::Unit::TestCase
     Service.save! id: @service.id, provider_key: @provider_key, backend_version: '2'
 
     application_key_one = @application.create_key
-    application_key_two = @application.create_key
 
     get '/transactions/authorize.xml', :provider_key => @provider_key,
                                        :app_id       => @application.id
@@ -118,7 +116,7 @@ class BackendVersionTest < Test::Unit::TestCase
 
     Service.save! id: @service.id, provider_key: @provider_key, backend_version: 'oauth'
 
-    get '/transactions/authorize.xml', :provider_key => @provider_key,
+    get '/transactions/oauth_authorize.xml', :provider_key => @provider_key,
                                        :app_id       => @application.id
 
     assert_authorized
@@ -128,7 +126,6 @@ class BackendVersionTest < Test::Unit::TestCase
     Service.save! id: @service.id, provider_key: @provider_key, backend_version: '2'
 
     application_key_one = @application.create_key
-    application_key_two = @application.create_key
 
     get '/transactions/authorize.xml', :provider_key => @provider_key,
                                        :app_id       => @application.id
@@ -144,13 +141,13 @@ class BackendVersionTest < Test::Unit::TestCase
 
     Service.save! id: @service.id, provider_key: @provider_key, backend_version: 'oauth'
 
-    get '/transactions/authorize.xml', :provider_key => @provider_key,
+    get '/transactions/oauth_authorize.xml', :provider_key => @provider_key,
                                        :app_id       => @application.id,
                                        :app_key      => 'invalid_key'
 
     assert_not_authorized
 
-    get '/transactions/authorize.xml', :provider_key => @provider_key,
+    get '/transactions/oauth_authorize.xml', :provider_key => @provider_key,
                                        :app_id       => @application.id,
                                        :app_key      => application_key_one
 

--- a/test/unit/validators/key_test.rb
+++ b/test/unit/validators/key_test.rb
@@ -19,30 +19,30 @@ module Validators
     end
 
     test 'succeeds if no application key is defined nor passed' do
-      assert Key.apply(@status, {})
+      assert Key.apply(@status, app_id: @application.id)
     end
 
     test 'succeeds if no application key is defined and blank one is passed' do
-      assert Key.apply(@status, :app_key => '')
+      assert Key.apply(@status, app_id: @application.id, app_key: '')
     end
 
     test 'succeeds if one application key is defined and the same is passed' do
       application_key = @application.create_key
-      assert Key.apply(@status, :app_key => application_key)
+      assert Key.apply(@status, app_id: @application.id, app_key: application_key)
     end
 
     test 'succeeds if multiple application keys are defined and one of them is passed' do
       application_key_one = @application.create_key
       application_key_two = @application.create_key
 
-      assert Key.apply(@status, :app_key => application_key_one)
-      assert Key.apply(@status, :app_key => application_key_two)
+      assert Key.apply(@status, app_id: @application.id, app_key: application_key_one)
+      assert Key.apply(@status, app_id: @application.id, app_key: application_key_two)
     end
 
     test 'fails if application key is defined but not passed' do
       @application.create_key
 
-      assert !Key.apply(@status, {})
+      assert !Key.apply(@status, app_id: @application.id)
 
       assert_equal 'application_key_invalid',    @status.rejection_reason_code
       assert_equal 'application key is missing', @status.rejection_reason_text
@@ -51,13 +51,13 @@ module Validators
     test 'fails if invalid application key is passed' do
       @application.create_key('foo')
 
-      assert !Key.apply(@status, :app_key => 'bar')
+      assert !Key.apply(@status, app_id: @application.id, app_key: 'bar')
 
       assert_equal 'application_key_invalid',          @status.rejection_reason_code
       assert_equal 'application key "bar" is invalid', @status.rejection_reason_text
     end
 
-    test 'succeeds if service backend version is 1, even when invalid keys are passed' do
+    test 'fails if invalid application key is passed, even when service backend version is 1' do
       service = Service.save!(:provider_key => 'provider_key',
                               :id => next_id,
                               :backend_version => 1)
@@ -71,7 +71,10 @@ module Validators
 
       application.create_key('foo')
 
-      assert Key.apply(status, :app_key => 'non_registered_key')
+      assert !Key.apply(status, app_id: application.id, app_key: 'non_registered_key')
+
+      assert_equal 'user_key_invalid',          status.rejection_reason_code
+      assert_equal 'user key is missing', status.rejection_reason_text
     end
   end
 end


### PR DESCRIPTION
There issue warns about two scenarios:

1. `backend_version == 1` (auth by `user_key`): can auth by `app_id` only
2. `backend_version == 2` (auth by `app_id` + `app_key`): can auth by `user_key` + `app_key`

Apparently this behavior was expected, since there was a test to ensure `user_key` and `app_id` are exchangeable:
https://github.com/3scale/apisonator/blob/706507842c2b9eea6e99b187630ea703a92021d9/test/integration/backend_version_test.rb#L23

In this PR I modified the validator to  require `user_key` when backend version is 1 and require `app_id` when backend version is 2.

This might be a breaking change, but I don't see a reason why `app_id` and `user_key` should be exchangeable. The test was introduced in a very old [commit](https://github.com/3scale/apisonator/commit/7895d2f58515d6fd1d9e69b19faa7107b3d8b5ce#diff-ffdbe6975a1f996364c1f01ae334274340c7ffb5237701282d8ddb9114941ca3) with almost no description and not part of a PR so the original intention is hard to guess.

Anyway, I'd say very few clients could notice a difference, since most of clients don't access apisonator directly but behind apicast, which already does this parameter validation.

**Issue**: https://issues.redhat.com/browse/THREESCALE-8964