### PR TITLE
Fix deploy

### DIFF
--- a/config/falcon.rb
+++ b/config/falcon.rb
@@ -7,10 +7,16 @@ require '3scale/backend/manifest'
 
 HOSTNAME = 'listener'
 
+module Falcon::Environment::Rackup
+  def rackup_path
+    File.expand_path('../config.ru', root)
+  end
+end
+
 service HOSTNAME do
   include Falcon::Environment::Rack
 
-  preload 'lib/3scale/prometheus_server.rb'
+  preload '../lib/3scale/prometheus_server.rb'
 
   manifest = ThreeScale::Backend::Manifest.report
   count manifest[:server_model][:workers].to_i

--- a/lib/3scale/backend/server/falcon.rb
+++ b/lib/3scale/backend/server/falcon.rb
@@ -4,7 +4,7 @@ module ThreeScale
       class Falcon
         extend ThreeScale::Backend::Server::Utils
 
-        CONFIG = 'falcon.rb'
+        CONFIG = 'config/falcon.rb'
 
         def self.start(global_options, options, args)
           # Falcon does not support:

--- a/openshift/distro/ubi/9/Dockerfile
+++ b/openshift/distro/ubi/9/Dockerfile
@@ -91,6 +91,11 @@ RUN cp -n openshift/3scale_backend.conf /etc/ \
  && touch /var/log/backend/3scale_backend{,_worker}.log \
  && chmod g+rw /var/log/backend/3scale_backend{,_worker}.log
 
+# Ensure safe defaults within the container for general case as well as to cover OpenShift specific case where the unprivileged user who runs the container is member of the root Linux group
+RUN chown -R 1001:0 /opt/ruby \
+    && chmod -R 750 /opt/ruby
+
+
 EXPOSE 3000
 
 USER 1001


### PR DESCRIPTION
The image fails to deploy, the reason is `falcon host` doesn't find the config file: `falcon.rb`.

This file is in fact not included in the image, because only files explicitly mentioned in `apisonator.gemspec` are included:

https://github.com/3scale/apisonator/blob/a9dc73444f6da99de237a4a29686b2347abddb77/apisonator.gemspec#L25-L38

The `Dockerfile` just unpacks those files in the image:

From: https://gitlab.cee.redhat.com/3scale/apisonator-midstream/-/blob/3scale-amp-2/distgit/containers/3scale-amp-backend/Dockerfile.in?ref_type=heads#L91
```
gem unpack "apisonator-${BACKEND_VERSION}.gem" --target=/opt/ruby \
```

The bug was introduced when I migrated from `falcon serve` to `falcon host`: https://github.com/3scale/apisonator/pull/427

I guess that PR didn't make it to MAS yet, otherwise somebody would have noticed. Anyway, to solve this I moved `falcon.rb` to under `config/`. This is the same folder where `puma.rb` is, so now it's also more consistent.
