### PR TITLE
More fixes to deploy

### DIFF
--- a/apisonator.gemspec
+++ b/apisonator.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.files << 'CHANGELOG.md'
   s.files << 'Rakefile'
   s.files << 'config.ru'
-  s.files << 'falcon_config.rb'
   # Gemfile* and gemspec are included here to support
   # running Bundler at gem install time.
   s.files << 'Gemfile'

--- a/config/falcon.rb
+++ b/config/falcon.rb
@@ -10,6 +10,8 @@ HOSTNAME = 'listener'
 service HOSTNAME do
   include Falcon::Environment::Rack
 
+  rackup_path 'config.ru'
+
   ipc_path '/tmp/apisonator.ipc'
 
   preload '../lib/3scale/prometheus_server.rb'

--- a/config/falcon.rb
+++ b/config/falcon.rb
@@ -10,7 +10,9 @@ HOSTNAME = 'listener'
 service HOSTNAME do
   include Falcon::Environment::Rack
 
-  preload 'lib/3scale/prometheus_server.rb'
+  ipc_path '/tmp/apisonator.ipc'
+
+  preload '../lib/3scale/prometheus_server.rb'
 
   manifest = ThreeScale::Backend::Manifest.report
   count manifest[:server_model][:workers].to_i
@@ -23,4 +25,6 @@ end
 
 service 'supervisor' do
   include Falcon::Environment::Supervisor
+
+  ipc_path '/tmp/apisonator_supervisor.ipc'
 end

--- a/lib/3scale/backend/server/falcon.rb
+++ b/lib/3scale/backend/server/falcon.rb
@@ -4,7 +4,7 @@ module ThreeScale
       class Falcon
         extend ThreeScale::Backend::Server::Utils
 
-        CONFIG = 'falcon_config.rb'
+        CONFIG = 'config/falcon.rb'
 
         def self.start(global_options, options, args)
           # Falcon does not support:


### PR DESCRIPTION
After https://github.com/3scale/apisonator/pull/429, alpha still fails to deploy, the error is:

```
Permission denied - bind(2) for /opt/ruby/apisonator-3.4.3/supervisor.ipc
```

That's because the image is created to run with the user `1001` and grants write permissions to that user, but Openshift ignores that and uses another used instead, which doesn't have the write permissions.

In order to solve that, I'm making some changes in the falcon config file to install its temporary files under `/tmp` which should have the proper permissions.

On the other hand, I found a way to move the falcon config file to under `config/` without the monkey patch, just calling the `rackup_path` method.