### PR TITLE
simplify Dockerfile

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -72,11 +72,7 @@ build: export DOCKERFILE?=$(DOCKERFILE_PATH)/Dockerfile ## Build dev image with 
 
 .PHONY: build-release
 build-release: export DOCKERFILE?=$(DOCKERFILE_PATH)/Dockerfile
-build-release: export BUILD_ARGS=--build-arg CACHE_FRIENDLY=false \
-	  --build-arg GEM_UPDATE=false \
-	  --build-arg BUNDLE_VERSION_MATCH=false \
-	  --build-arg BUNDLE_WITHOUT=development:test \
-	  --build-arg RACK_ENV=production
+build-release: export BUILD_ARGS=--build-arg RACK_ENV=production
 build-release: ## Build dev image with release-like settings.
 	$(MAKE) -f $(MKFILE_PATH) build
 

--- a/openshift/distro/ubi/9/Dockerfile
+++ b/openshift/distro/ubi/9/Dockerfile
@@ -6,10 +6,6 @@
 #
 # - RUBY_VERSION: Ruby version used.
 # - BUILD_DEPS: Packages needed to build/install the project.
-# - BUNDLE_VERSION_MATCH: Install the Bundler version used by the lockfile
-#                         instead of using the SCL version.
-# - BUNDLE_GEMFILE: Gemfile name to pin Bundler to.
-# - BUNDLE_WITHOUT: List of Bundler groups to skip.
 # - PUMA_WORKERS: Default number of Puma workers to serve the app.
 #
 # Profiles you should use:
@@ -19,9 +15,6 @@
 #
 # - Development/Test: just use default values.
 # - Release:
-#   - GEM_UPDATE: false
-#   - BUNDLE_VERSION_MATCH: false
-#   - BUNDLE_WITHOUT: development:test
 #   - PUMA_WORKERS: number of Puma worker processes - depends on intended usage,
 #                   with number of cpus being a good heuristic.
 #
@@ -32,7 +25,8 @@ ARG RUBY_VERSION="3.3"
 ARG BUILD_DEPS="tar make file findutils git patch gcc automake autoconf libtool redhat-rpm-config openssl-devel ruby-devel"
 
 RUN microdnf module enable -y "ruby:${RUBY_VERSION}" \
- && microdnf install -y --nodocs ${BUILD_DEPS}
+ && microdnf install -y --nodocs ${BUILD_DEPS} \
+ && microdnf clean all
 
 # Copy sources
 WORKDIR /opt/source

--- a/openshift/distro/ubi/9/Dockerfile
+++ b/openshift/distro/ubi/9/Dockerfile
@@ -38,41 +38,42 @@ RUN microdnf module enable -y "ruby:${RUBY_VERSION}" \
 WORKDIR /opt/source
 COPY ./ ./
 
-# Setup Bundler
+# setup system
+RUN cp -n openshift/3scale_backend.conf /etc/ \
+ && chmod 660 /etc/3scale_backend.conf \
+ && cp -n openshift/backend-cron /usr/local/sbin/backend-cron \
+ && mkdir -p -m 0770 /var/run/3scale/ \
+ && mkdir -p -m 0770 /var/log/backend/ \
+ && touch /var/log/backend/3scale_backend{,_worker}.log \
+ && chmod g+rw /var/log/backend/3scale_backend{,_worker}.log \
+ && chown -R 1001 . && chmod g+w /opt
+
+# Install bundler globally (as root)
 RUN BUNDLED_WITH=$(awk '/BUNDLED WITH/ { getline; print $1 }' Gemfile.lock) \
  && gem install --no-document bundler:$BUNDLED_WITH \
  && echo Using $(bundle --version), originally bundled with ${BUNDLED_WITH}
 
+USER 1001
+
 # Builds a clean source tree and deploys it with Bundler.
-RUN cp -n openshift/3scale_backend.conf /etc/ \
- && chmod 644 /etc/3scale_backend.conf \
- && BACKEND_VERSION=$(gem build apisonator.gemspec | \
+RUN BACKEND_VERSION=$(gem build apisonator.gemspec | \
       sed -n -e 's/^\s*Version\:\s*\([^[:space:]]*\)$/\1/p') \
- && gem unpack "apisonator-${BACKEND_VERSION}.gem" --target=/opt/ruby \
- && mv "/opt/ruby/apisonator-${BACKEND_VERSION}" /opt/app \
- && rm -rf /opt/ruby
+ && gem unpack "apisonator-${BACKEND_VERSION}.gem" --target=/tmp/ruby \
+ && mv "/tmp/ruby/apisonator-${BACKEND_VERSION}" /opt/app \
+ && rm -rf /tmp/ruby
 
 WORKDIR /opt/app
 
 # Install ruby dependencies and put things at the right places
 RUN bundle config set --local build.nokogiri --use-system-libraries \
- && bundle config --local without development:test \
+ && bundle config set --local without development:test \
  && bundle config set --local deployment true \
- && bundle config --local path /opt/app \
  && bundle install --jobs $(grep -c processor /proc/cpuinfo) \
  && cp /opt/source/openshift/config/puma.rb config/ \
- && cp -n /opt/source/openshift/backend-cron /usr/local/sbin/backend-cron \
  && cp -n /opt/source/openshift/entrypoint.sh ./ \
- && rm -rf /opt/source \
- && mkdir -p -m 0770 /var/run/3scale/ \
- && mkdir -p -m 0770 /var/log/backend/ \
- && touch /var/log/backend/3scale_backend{,_worker}.log \
- && chmod g+rw /var/log/backend/3scale_backend{,_worker}.log \
- && chmod -R g+w .
+ && rm -rf /opt/source
 
 EXPOSE 3000
-
-USER 1001
 
 ARG PUMA_WORKERS=1
 ARG RACK_ENV=production

--- a/openshift/distro/ubi/9/Dockerfile
+++ b/openshift/distro/ubi/9/Dockerfile
@@ -28,79 +28,51 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
-ENV HOME=/home
-WORKDIR "${HOME}/app"
-
 ARG RUBY_VERSION="3.3"
-
-RUN microdnf module enable -y "ruby:${RUBY_VERSION}" \
- && chown -R 1001:1001 "${HOME}"
-
 ARG BUILD_DEPS="tar make file findutils git patch gcc automake autoconf libtool redhat-rpm-config openssl-devel ruby-devel"
 
-RUN microdnf install -y --nodocs ${BUILD_DEPS}
-
-# Bundler should be kept as-is for productisation
-ARG BUNDLE_VERSION_MATCH=true
-# If the above is false
-ARG BUNDLE_VERSION="2.3.5"
-
-ARG BUNDLE_GEMFILE=Gemfile
-ARG BUNDLE_WITHOUT=development:test
-
-COPY --chown=1001:1001 ${BUNDLE_GEMFILE}.lock "${HOME}/app/"
-
-RUN mkdir -p "${HOME}/.gem/bin" \
- && echo "gem: --bindir ~/.gem/bin --install-dir /usr/share/gems" > "${HOME}/.gemrc"
-
-RUN gem uninstall --executables bundler \
- && BUNDLED_WITH=$(cat ${BUNDLE_GEMFILE}.lock | \
-      grep -A 1 "^BUNDLED WITH$" | tail -n 1 | sed -e 's/\s//g') \
- && if test "${BUNDLE_VERSION_MATCH}x" = "truex"; then \
-      gem install -N bundler --version "${BUNDLED_WITH}"; \
-    else \
-      gem install -N bundler --version "${BUNDLE_VERSION}"; \
-    fi \
- && echo Using $(bundle --version), originally bundled with ${BUNDLED_WITH} \
- && bundle config --local silence_root_warning 1 \
- && bundle config --local disable_shared_gems 1 \
- && bundle config --local without ${BUNDLE_WITHOUT} \
- && bundle config --local gemfile ${BUNDLE_GEMFILE}
+RUN microdnf module enable -y "ruby:${RUBY_VERSION}" \
+ && microdnf install -y --nodocs ${BUILD_DEPS}
 
 # Copy sources
-COPY --chown=1001:1001 ./ "${HOME}/app/"
+WORKDIR /opt/source
+COPY ./ ./
+
+# Setup Bundler
+RUN BUNDLED_WITH=$(awk '/BUNDLED WITH/ { getline; print $1 }' Gemfile.lock) \
+ && gem install --no-document bundler:$BUNDLED_WITH \
+ && echo Using $(bundle --version), originally bundled with ${BUNDLED_WITH}
 
 # Builds a clean source tree and deploys it with Bundler.
-# Sets the right configuration and permissions.
 RUN cp -n openshift/3scale_backend.conf /etc/ \
  && chmod 644 /etc/3scale_backend.conf \
  && BACKEND_VERSION=$(gem build apisonator.gemspec | \
       sed -n -e 's/^\s*Version\:\s*\([^[:space:]]*\)$/\1/p') \
  && gem unpack "apisonator-${BACKEND_VERSION}.gem" --target=/opt/ruby \
- && cd "/opt/ruby/apisonator-${BACKEND_VERSION}" \
- && cp -a ${HOME}/app/.bundle "/opt/ruby/apisonator-${BACKEND_VERSION}/" \
- && bundle config --local path "/opt/ruby/apisonator-${BACKEND_VERSION}/" \
+ && mv "/opt/ruby/apisonator-${BACKEND_VERSION}" /opt/app \
+ && rm -rf /opt/ruby
+
+WORKDIR /opt/app
+
+# Install ruby dependencies and put things at the right places
+RUN bundle config set --local build.nokogiri --use-system-libraries \
+ && bundle config --local without development:test \
+ && bundle config set --local deployment true \
+ && bundle config --local path /opt/app \
  && bundle install --jobs $(grep -c processor /proc/cpuinfo) \
- && ln -s ${PWD} /opt/app \
- && cp ${HOME}/app/openshift/config/puma.rb ./config/ \
- && cp -n ${HOME}/app/openshift/backend-cron /usr/local/sbin/backend-cron \
- && cp -n ${HOME}/app/openshift/entrypoint.sh ./ \
- && rm -rf ${HOME}/app \
+ && cp /opt/source/openshift/config/puma.rb config/ \
+ && cp -n /opt/source/openshift/backend-cron /usr/local/sbin/backend-cron \
+ && cp -n /opt/source/openshift/entrypoint.sh ./ \
+ && rm -rf /opt/source \
  && mkdir -p -m 0770 /var/run/3scale/ \
  && mkdir -p -m 0770 /var/log/backend/ \
  && touch /var/log/backend/3scale_backend{,_worker}.log \
- && chmod g+rw /var/log/backend/3scale_backend{,_worker}.log
-
-# Ensure safe defaults within the container for general case as well as to cover OpenShift specific case where the unprivileged user who runs the container is member of the root Linux group
-RUN chown -R 1001:0 /opt/ruby \
-    && chmod -R 750 /opt/ruby
-
+ && chmod g+rw /var/log/backend/3scale_backend{,_worker}.log \
+ && chmod -R g+w .
 
 EXPOSE 3000
 
 USER 1001
-
-WORKDIR /opt/app
 
 ARG PUMA_WORKERS=1
 ARG RACK_ENV=production
@@ -113,4 +85,4 @@ ENV TZ=:/etc/localtime \
     CONFIG_WORKERS_LOG_FILE=/dev/stdout \
     PUMA_WORKERS=${PUMA_WORKERS}
 
-ENTRYPOINT ["/bin/bash", "--", "/opt/app/entrypoint.sh"]
+ENTRYPOINT ["/opt/app/entrypoint.sh"]


### PR DESCRIPTION
Tried to simplify the Dockerfile to avoid issues running on latest Fedora 42.

```
🐚 podman run --rm -it --entrypoint=/bin/bash quay.io/3scale/apisonator
Error: creating container 3734a959f1fadf280ac561ba32099e50f3230bef2f30871d1d03a1805164012d workdir: mkdir /home/akostadi/.local/share/containers/storage/overlay/99149e0b7a284c2017042e1924fc05c57fcc6ef285cca20c1d85e9e4fedfc9e3/merged/opt/app: file exists
```

Works for me locally. Should work with porta-dev-tools too.