### PR TITLE
allow setting bind address for listener

### DIFF
--- a/bin/3scale_backend
+++ b/bin/3scale_backend
@@ -39,6 +39,10 @@ class Runner
       c.arg_name 'NUMBER'
       c.default_value '3000'
       c.flag :p, :port
+      c.desc 'Host/IP address where backend binds for connections'
+      c.arg_name 'HOST'
+      c.default_value '0.0.0.0'
+      c.flag :h, :host
       c.desc 'Filename where backend writes its PID'
       c.arg_name 'FILENAME'
       c.flag :pidfile
@@ -165,8 +169,8 @@ class Runner
       do_command :start, global_options, options, args
     end
 
-    c.example '3scale_backend start -p 5001 -d --pidfile backend.pid -l /var/log/backend.log -x /var/log/backend.err.log',
-              desc: 'Listen on port 5001, daemonize with pidfile, write separate logs for requests and errors'
+    c.example '3scale_backend start -p 5001 -h 127.0.0.1 -d --pidfile backend.pid -l /var/log/backend.log -x /var/log/backend.err.log',
+              desc: 'Listen on localhost port 5001, daemonize with pidfile, write separate logs for requests and errors'
   end
 
   desc 'Stops the backend server'

--- a/config/falcon.rb
+++ b/config/falcon.rb
@@ -20,8 +20,9 @@ service HOSTNAME do
   count manifest[:server_model][:workers].to_i
 
   port = ENV.fetch("FALCON_PORT", 3001).to_i
+  host = ENV.fetch("FALCON_HOST", "0.0.0.0")
   endpoint Async::HTTP::Endpoint
-             .parse("http://0.0.0.0:#{port}")
+             .parse("http://#{host}:#{port}")
              .with(protocol: Async::HTTP::Protocol::HTTP11)
 end
 

--- a/lib/3scale/backend/server/falcon.rb
+++ b/lib/3scale/backend/server/falcon.rb
@@ -17,6 +17,7 @@ module ThreeScale
           return unless manifest
 
           ENV["FALCON_PORT"] ||= options[:port]
+          ENV["FALCON_HOST"] ||= options[:host]
 
           argv = ['falcon', 'host']
           argv_add argv, true, CONFIG

--- a/lib/3scale/backend/server/puma.rb
+++ b/lib/3scale/backend/server/puma.rb
@@ -24,7 +24,8 @@ module ThreeScale
           return unless manifest
           argv = ['puma']
           argv_add argv, options[:daemonize], '-d'
-          argv_add argv, options[:port], '-p', options[:port]
+          argv_add argv, options[:port] && !options[:host], '-p', options[:port]
+          argv_add argv, options[:host], '-b', "tcp://#{options[:host]}#{":" + options[:port] if options[:port]}"
           argv_add argv, options[:logfile], '--redirect-stdout', options[:logfile]
           argv_add argv, options[:errorfile], '--redirect-stderr', options[:errorfile]
           argv << '--redirect-append' if [options[:logfile], options[:errorfile]].any?


### PR DESCRIPTION
Mostly useful if you need to bind to IPv6 like [::] And binding to IPv6 is mostly useful so that running under podman you can connect to the exported port boh through IPv4 and IPv6.

See https://github.com/containers/podman/issues/22959#issuecomment-2318736143

tl;dr; if listener is bound to IPv4 inside the container the published port only works over IPv4. While if listener binds to IPv6, the published port can be accessed over both - IPv4 and IPv6. With `slirp4netns` it worked either way.

And the issue is that on modern linux, `localhost` resolves to IPv6 and IPv4, then IPv6 is chosen by default. That's why for max compatibility we want to listen on IPv6.

Assisted-by: Claude Code