### PR TITLE
THREESCALE-12222: Invoke stats cleaner with no connection URLs by default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -285,13 +285,9 @@ namespace :stats do
   task :cleanup, [:redis_urls, :log_deleted_keys] do |_, args|
     redis_conns = redis_conns(args[:redis_urls])
 
-    if redis_conns.empty?
-      puts 'No Redis URLs specified'
-      exit(false)
-    end
-
     ThreeScale::Backend::Stats::Cleaner.delete!(
-      redis_conns, log_deleted_keys: logger_for_deleted_keys(args[:log_deleted_keys])
+      redis_conns: redis_conns,
+      log_deleted_keys: logger_for_deleted_keys(args[:log_deleted_keys])
     )
   end
 

--- a/lib/3scale/backend/stats/cleaner.rb
+++ b/lib/3scale/backend/stats/cleaner.rb
@@ -1,4 +1,5 @@
 require '3scale/backend/stats/stats_parser'
+require 'timeout'
 
 module ThreeScale
   module Backend
@@ -123,9 +124,31 @@ module ThreeScale
 
           private
 
-          # Delete the stags keys from the default storage Redis instance
+          # Check if a Redis connection supports SCAN command
+          # Returns true if supported, false otherwise
+          def supports_scan?(redis_conn)
+            begin
+              Timeout.timeout(3) do
+                redis_conn.scan(0, count: 1)
+                true
+              end
+            rescue Timeout::Error
+              logger.error("Timeout when calling SCAN command.")
+              false
+            rescue => e
+              logger.error("Error #{e} occurred when calling SCAN command.")
+              false
+            end
+          end
+
+          # Delete the stats keys from the default storage Redis instance
           def delete_from_storage(services, log_deleted_keys)
             redis = Storage.instance
+
+            unless supports_scan?(redis)
+              logger.error("Storage instance doesn't support SCAN command (e.g. Twemproxy is used). Cannot proceed with stats deletion.")
+              return
+            end
 
             begin
               delete_keys(redis, services, log_deleted_keys)

--- a/lib/3scale/backend/stats/cleaner.rb
+++ b/lib/3scale/backend/stats/cleaner.rb
@@ -88,11 +88,8 @@ module ThreeScale
             logger.info("Going to delete the stats keys for these services: #{services.to_a}")
 
             unless services.empty?
-              if redis_conns.empty?
-                delete_from_storage services, log_deleted_keys
-              else
-                delete_from_server_list services, redis_conns, log_deleted_keys
-              end
+              redis_conns = [Storage.instance] if redis_conns.empty?
+              delete_from_server_list services, redis_conns, log_deleted_keys
             end
 
             logger.info("Finished deleting the stats keys for these services: #{services.to_a}")
@@ -141,30 +138,22 @@ module ThreeScale
             end
           end
 
-          # Delete the stats keys from the default storage Redis instance
-          def delete_from_storage(services, log_deleted_keys)
-            redis = Storage.instance
-
-            unless supports_scan?(redis)
-              logger.error("Storage instance doesn't support SCAN command (e.g. Twemproxy is used). Cannot proceed with stats deletion.")
-              return
-            end
-
-            begin
-              delete_keys(redis, services, log_deleted_keys)
-              with_retries { remove_services_from_delete_set(services) }
-            rescue => e
-              handle_redis_exception(e, redis)
-            end
-          end
-
-          # Legacy method that works for a list of individual servers, can be used with
-          # Twemproxy, but does not support such Redis connection options as username/password, TLS etc.
+          # Delete stats keys from Redis
+          # Legacy method that works with a list of individual Redis server connections.
+          # These should be direct connections to Redis servers (not through a proxy like Twemproxy).
+          # However, we check for SCAN support to protect against misconfigurations.
+          # Note: This method does not support Redis connection options like username/password, TLS etc.
+          # For those features, use the default storage instance (redis_conns not provided).
           def delete_from_server_list(services, redis_conns, log_deleted_keys)
             _ok, failed = redis_conns.partition do |redis_conn|
               begin
-                delete_keys redis_conn, services, log_deleted_keys
-                true
+                if supports_scan?(redis_conn)
+                  delete_keys redis_conn, services, log_deleted_keys
+                  true
+                else
+                  logger.error("Redis instance #{redis_conn} doesn't support SCAN command (e.g. Twemproxy is used). Cannot proceed with stats deletion.")
+                  false
+                end
               rescue => e
                 handle_redis_exception(e, redis_conn)
                 false

--- a/openshift/backend-cron
+++ b/openshift/backend-cron
@@ -31,7 +31,7 @@ reschedule_failed_jobs_thread = run_rake_task_in_thread(
 )
 
 delete_stats_thread = run_rake_task_in_thread(
-  "stats:cleanup[#{ENV['CONFIG_REDIS_PROXY']}]",
+  "stats:cleanup",
   (ENV['DELETE_STATS_FREQ'] || DEFAULT_DELETE_STATS_FREQ).to_i,
 )
 

--- a/spec/unit/stats/cleaner_spec.rb
+++ b/spec/unit/stats/cleaner_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../../test/test_helpers/storage'
+
 module ThreeScale
   module Backend
     module Stats
@@ -7,16 +9,6 @@ module ThreeScale
         let(:storage) { Backend::Storage.instance }
         let(:storage_instances) { storage.send(:proxied_instances) }
         let(:logger) { Backend.logger }
-
-        # Helper to detect if we're using Twemproxy (which doesn't support SCAN)
-        def self.using_twemproxy?
-          # Parse the URL and check if it's using Twemproxy's default port (22121)
-          proxy_url = ENV['CONFIG_REDIS_PROXY']
-          return false unless proxy_url
-
-          parsed_uri = URI.parse(ThreeScale::Backend::Storage::Helpers.send(:to_redis_uri, proxy_url))
-          parsed_uri.port == 22121
-        end
 
         before do
           allow(logger).to receive(:info)
@@ -125,22 +117,6 @@ module ThreeScale
                   expect(log_to).to have_received(:puts).with("#{k} #{v}")
                 end
               end
-
-              it 'deletes only the stats of services marked to be deleted' do
-                Cleaner.delete!(**delete_options.merge(log_deleted_keys: log_to))
-
-                expect(keys_not_to_be_deleted.keys.all? { |key| storage.exists?(key) })
-                  .to be true
-
-                expect(keys_to_be_deleted.keys.none? { |key| storage.exists?(key) })
-                  .to be true
-              end
-
-              it 'deletes the services from the set of marked to be deleted' do
-                Cleaner.delete!(**delete_options.merge(log_deleted_keys: log_to))
-
-                expect(storage.smembers(redis_set_marked_to_be_deleted)).to be_empty
-              end
             end
           end
 
@@ -167,44 +143,67 @@ module ThreeScale
             end
           end
 
-          context 'when redis_conns is provided' do
-            let(:delete_options) { { redis_conns: storage_instances } }
+          shared_examples 'stats deletion with individual servers list' do
+            it 'SCAN is not called on the backend storage instance, only on individual servers' do
+              services_to_be_deleted.each do |service|
+                Cleaner.mark_service_to_be_deleted(service)
+              end
 
-            include_examples 'delete behavior'
+              allow(storage).to receive(:scan).and_call_original
+              storage_instances.each do |instance|
+                allow(instance).to receive(:scan).and_call_original
+              end
+
+              Cleaner.delete!(**delete_options)
+
+              # SCAN should NOT be called on Storage.instance when redis_conns is provided
+              expect(storage).not_to have_received(:scan)
+
+              storage_instances.each do |instance|
+                expect(instance).to have_received(:scan).at_least(1).times
+              end
+            end
 
             context 'when there are redis connection errors' do
-              let(:redis) { storage_instances.first }
-
               before do
                 services_to_be_deleted.each do |service|
                   Cleaner.mark_service_to_be_deleted(service)
                 end
 
                 allow(logger).to receive(:error)
+                allow(storage).to receive(:scan).and_call_original
 
-                # Using scan just because it's the first command called.
-                allow(redis)
-                  .to receive(:scan).and_raise(Errno::ECONNREFUSED)
+                # Mock scan to raise connection error - simulates Redis server being unreachable
+                # This will be caught by supports_scan? check which prevents hanging
+                storage_instances.each do |instance|
+                  allow(instance).to receive(:scan).and_raise(Errno::ECONNREFUSED)
+                end
               end
 
-              it 'logs an error without raising' do
+              it 'detects connection failure and logs errors without raising' do
                 expect { Cleaner.delete!(**delete_options) }.not_to raise_error
-                expect(logger).to have_received(:error)
-              end
+                # Error logged from supports_scan? when it catches the exception
+                # Plus error from partition block returning false
+                expect(logger).to have_received(:error).at_least(:once)
 
-              it 'retries' do
-                Cleaner.delete!(**delete_options)
-                expect(redis)
-                  .to have_received(:scan)
-                  .exactly(Cleaner.const_get(:MAX_RETRIES_REDIS_ERRORS)).times
+                # Keys are not deleted
+                expect(keys_to_be_deleted.keys.all? { |key| storage.exists?(key) }).to be true
+                expect(storage.smembers(redis_set_marked_to_be_deleted)).to eq(services_to_be_deleted)
               end
             end
+          end
+
+          context 'when redis_conns is provided' do
+            let(:delete_options) { { redis_conns: storage_instances } }
+
+            include_examples 'delete behavior'
+            include_examples 'stats deletion with individual servers list'
           end
 
           context 'when redis_conns is not provided' do
             let(:delete_options) { {} }
 
-            if using_twemproxy?
+            if TestHelpers::Storage::Mock.using_twemproxy?
               include_examples 'delete is not supported with twemproxy'
             else
               include_examples 'delete behavior'

--- a/spec/unit/stats/cleaner_spec.rb
+++ b/spec/unit/stats/cleaner_spec.rb
@@ -6,7 +6,17 @@ module ThreeScale
 
         let(:storage) { Backend::Storage.instance }
         let(:storage_instances) { storage.send(:proxied_instances) }
-        let(:logger) { object_double(Backend.logger) }
+        let(:logger) { Backend.logger }
+
+        # Helper to detect if we're using Twemproxy (which doesn't support SCAN)
+        def self.using_twemproxy?
+          # Parse the URL and check if it's using Twemproxy's default port (22121)
+          proxy_url = ENV['CONFIG_REDIS_PROXY']
+          return false unless proxy_url
+
+          parsed_uri = URI.parse(ThreeScale::Backend::Storage::Helpers.send(:to_redis_uri, proxy_url))
+          parsed_uri.port == 22121
+        end
 
         before do
           allow(logger).to receive(:info)
@@ -132,9 +142,38 @@ module ThreeScale
                 expect(storage.smembers(redis_set_marked_to_be_deleted)).to be_empty
               end
             end
+          end
+
+          shared_examples 'delete is not supported with twemproxy' do
+            it "detects that SCAN is not supported and returns early" do
+              services_to_be_deleted.each do |service|
+                Cleaner.mark_service_to_be_deleted(service)
+              end
+
+              # Mock the storage to verify SCAN is not called on it
+              allow(storage).to receive(:scan).and_call_original
+              allow(logger).to receive(:error)
+
+              Cleaner.delete!(**delete_options)
+
+              # Verify SCAN was called just one time - in supports_scan? to verify it's supported
+              expect(storage).to have_received(:scan).exactly(1).times
+
+              # Verify error was logged
+              expect(logger).to have_received(:error).with(/doesn't support SCAN/)
+
+              # Verify keys were NOT deleted (since operation was skipped)
+              expect(keys_to_be_deleted.keys.all? { |key| storage.exists?(key) }).to be true
+            end
+          end
+
+          context 'when redis_conns is provided' do
+            let(:delete_options) { { redis_conns: storage_instances } }
+
+            include_examples 'delete behavior'
 
             context 'when there are redis connection errors' do
-              let(:redis) { delete_options[:redis_conns]&.first || storage }
+              let(:redis) { storage_instances.first }
 
               before do
                 services_to_be_deleted.each do |service|
@@ -162,16 +201,14 @@ module ThreeScale
             end
           end
 
-          context 'when redis_conns is provided' do
-            let(:delete_options) { { redis_conns: storage_instances } }
-
-            include_examples 'delete behavior'
-          end
-
           context 'when redis_conns is not provided' do
             let(:delete_options) { {} }
 
-            include_examples 'delete behavior'
+            if using_twemproxy?
+              include_examples 'delete is not supported with twemproxy'
+            else
+              include_examples 'delete behavior'
+            end
           end
         end
 

--- a/test/test_helpers/storage.rb
+++ b/test/test_helpers/storage.rb
@@ -39,13 +39,16 @@ module TestHelpers
       private_constant :DEFAULT_NODES
 
       class << self
-        def nodes
-          # Return original URL unless we are testing on a twemproxy
-          uri = URI(ThreeScale::Backend.configuration.redis.proxy)
-          return [uri.to_s] if uri.port != DEFAULT_TWEMPROXY_PORT
+        def proxy_uri
+          @proxy_uri ||= URI(ThreeScale::Backend.configuration.redis.proxy)
+        end
 
-          # Return proxied shards if testing on a twemproxy
-          @nodes || DEFAULT_NODES
+        def using_twemproxy?
+          @using_twemproxy ||= proxy_uri.port == DEFAULT_TWEMPROXY_PORT
+        end
+
+        def nodes
+          @nodes ||= using_twemproxy? ? DEFAULT_NODES : [proxy_uri.to_s]
         end
 
         def mock_storage_clients

--- a/test/test_helpers/storage.rb
+++ b/test/test_helpers/storage.rb
@@ -101,13 +101,13 @@ module TestHelpers
                 inner.send(m, *args, **kwargs, &blk)
               end
 
-              def respond_to_missing?(m)
-                inner.respond_to_missing? m
+              def respond_to_missing?(m, include_all=false)
+                inner.respond_to?(m, include_all)
               end
 
               # Needed to call Redis::Namespace.new(). Used in WorkerAsync.
-              def respond_to?(m)
-                inner.respond_to?(m)
+              def respond_to?(m, include_all=false)
+                inner.respond_to?(m, include_all)
               end
 
               private


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/THREESCALE-12222

To test a specific rspec locally with twemproxy, here are the steps:

1. Copy the twemproxy file:
```
cp script/config/examples/twemproxy.yml script/config/
```
2. Stop the currently running redis (to free the port `6379`)
3. Run podman-compose with twemproxy:
```
podman-compose -f script/config/podman-compose.yml up redis-master twemproxy redis-shard1 redis-shard2 redis-shard3
```
4. Add the following to `.env.test`:
```
CONFIG_LOG_PATH=/dev/stdout

CONFIG_QUEUES_READ_TIMEOUT=10
CONFIG_QUEUES_WRITE_TIMEOUT=10
CONFIG_QUEUES_MASTER_NAME=redis://localhost:6379
CONFIG_REDIS_READ_TIMEOUT=10
CONFIG_REDIS_WRITE_TIMEOUT=10
CONFIG_REDIS_PROXY=redis://localhost:22121
```
5. Run a specific test in sync and async modes:
```
CONFIG_REDIS_ASYNC=true bundle exec rake "spec:specific[spec/unit/stats/cleaner_spec.rb]"
CONFIG_REDIS_ASYNC=false bundle exec rake "spec:specific[spec/unit/stats/cleaner_spec.rb]"
```