### PR TITLE
THREESCALE-14345: Upgrade rack to 3.1.21 (for 3scale 2.16)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
     puma (6.5.0)
       nio4r (~> 2.0)
     racc (1.8.0)
-    rack (3.1.19)
+    rack (3.1.21)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)


### PR DESCRIPTION
Same as https://github.com/3scale/apisonator/pull/458, but for 3scale 2.16.

Fix multiple CVEs including:
- CVE-2026-34827 3scale-amp2/backend-rhel8: Rack: Denial of Service via crafted multipart/form-data requests [3amp-2.15]
- CVE-2026-34829 3scale-amp2/backend-rhel8: Rack: Denial of Service via unbounded multipart file upload [3amp-2.15]
- CVE-2026-22860 3scale-amp2/backend-rhel8: Rack Directory Traversal via Rack:Directory [3amp-2.15]


See https://github.com/rack/rack/blob/main/CHANGELOG.md#3121---2026-04-01

Fixes:
- https://redhat.atlassian.net/browse/THREESCALE-14345
- https://redhat.atlassian.net/browse/THREESCALE-14295
- https://redhat.atlassian.net/browse/THREESCALE-14489


