### PR TITLE
THREESCALE-14619: Remove the invalid default value for CONFIG_LOG_PATH

### DIFF
--- a/openshift/backend-cron
+++ b/openshift/backend-cron
@@ -3,11 +3,6 @@
 DEFAULT_RESCHEDULE_JOBS_FREQ = 300
 DEFAULT_DELETE_STATS_FREQ = 60*60*24 # 1 day
 
-# The logger used in the delete stats code defaults to /tmp/backend_logger.log
-# When running this executable STDOUT is more convenient to check that
-# everything is working correctly.
-ENV['CONFIG_LOG_PATH'] ||= 'dev/stdout'
-
 def run_rake_task_in_thread(name, freq, check_once = false)
   Thread.new do
     loop do


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/THREESCALE-14619

`dev/stdout` is an invalid log path. Removing the setting results in using other defaults for the log, and in OpenShift environment it defaults to `STDOUT` anyway, so we don't need to set the variable.
