### PR TITLE
THREESCALE-14624: log when waiting to reconnect

### DIFF
--- a/lib/3scale/backend/errors.rb
+++ b/lib/3scale/backend/errors.rb
@@ -329,7 +329,7 @@ module ThreeScale
 
     CONNECTION_ERRORS = [
       Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ECONNABORTED,
-      Errno::EPIPE, Errno::EAGAIN, BrokenPipeline, EOFError, OpenSSL::SSL::SSLError
+      Errno::EPIPE, Errno::EAGAIN, BrokenPipeline, EOFError, OpenSSL::SSL::SSLError, Errno::ENOENT
     ]
   end
 end

--- a/lib/3scale/backend/storage_async/client.rb
+++ b/lib/3scale/backend/storage_async/client.rb
@@ -82,6 +82,7 @@ module ThreeScale
             close
 
             if attempt < @opts[:reconnect_attempts]
+              Backend.logger.warn "Failed Redis connect (attempt #{attempt+1}/#{@opts[:reconnect_attempts]}): #{e.message}"
               attempt += 1
               sleep @opts[:reconnect_wait_seconds]
               retry


### PR DESCRIPTION
**Jira issue**

https://redhat.atlassian.net/browse/THREESCALE-14624

**Description**

Read the description at the Jira issue, but summarizing, add a log trace when the async client loses the connection to Redis and waits for reconnect. Without the log, the customers are confused as they think the pod is frozen.

This PR also adds ENOENT to the list of expected connection errors, so we wait for reconnect also when targeting a unix socket.