### PR TITLE
Fix circular dependency when Bugsnag is enabled

### DIFF
--- a/lib/3scale/backend/util.rb
+++ b/lib/3scale/backend/util.rb
@@ -1,6 +1,5 @@
 require 'pathname'
 require 'etc'
-require '3scale/backend/logging'
 
 module ThreeScale
   module Backend


### PR DESCRIPTION
The pods at staging fail to start because a regression caused by https://github.com/3scale/apisonator/pull/452

```
lib/3scale/backend/logging/external/impl/bugsnag.rb:58:in `block in configure': uninitialized constant ThreeScale::Backend::Util (NameError)

                  config.project_root = Backend::Util.root_dir
```

`Util` depends on `Logging` which depends on `Util`

The fix is to remove the `require` causing the loop, it's redundant anyway.