### PR TITLE
THREESCALE-14624: log when waiting to reconnect [Backport 2.16]

### DIFF
--- a/lib/3scale/backend/errors.rb
+++ b/lib/3scale/backend/errors.rb
@@ -315,7 +315,7 @@ module ThreeScale
 
     CONNECTION_ERRORS = [
       Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ECONNABORTED,
-      Errno::EPIPE, Errno::EAGAIN, BrokenPipeline, EOFError, OpenSSL::SSL::SSLError
+      Errno::EPIPE, Errno::EAGAIN, BrokenPipeline, EOFError, OpenSSL::SSL::SSLError, Errno::ENOENT
     ]
   end
 end

--- a/lib/3scale/backend/storage_async/client.rb
+++ b/lib/3scale/backend/storage_async/client.rb
@@ -80,6 +80,7 @@ module ThreeScale
             close
 
             if attempt < @opts[:reconnect_attempts]
+              Backend.logger.warn "Failed Redis connect (attempt #{attempt+1}/#{@opts[:reconnect_attempts]}): #{e.message}"
               attempt += 1
               sleep @opts[:reconnect_wait_seconds]
               retry


### PR DESCRIPTION
This backports https://github.com/3scale/apisonator/pull/463 to 2.16

**Jira issue:**

https://redhat.atlassian.net/browse/THREESCALE-14624