### PR TITLE
THREESCALE-14671: Fix leaking connections to sentinels [2.16 hotfix]

### DIFF
--- a/lib/3scale/backend/async_redis/sentinels_client_acl_tls.rb
+++ b/lib/3scale/backend/async_redis/sentinels_client_acl_tls.rb
@@ -15,16 +15,28 @@ module ThreeScale
           @role = config[:role] || :master
 
           @sentinel_credentials = config[:sentinel_username], config[:sentinel_password]
+          @sentinel_clients = {}
           @protocol = protocol
           @config = config
           @pool = connect(**options)
         end
 
+        def close
+          @sentinel_clients.each_value(&:close)
+          @sentinel_clients.clear
+          super
+        end
+
         private
+
+        def sentinel_client_for(sentinel_endpoint)
+          @sentinel_clients[sentinel_endpoint] ||=
+            Async::Redis::Client.new(sentinel_endpoint, protocol: Protocol::ExtendedRESP2.new(credentials: @sentinel_credentials), limit: 1)
+        end
 
         def resolve_master
           @sentinel_endpoints.each do |sentinel_endpoint|
-            client = Async::Redis::Client.new(sentinel_endpoint, protocol: Protocol::ExtendedRESP2.new(credentials: @sentinel_credentials))
+            client = sentinel_client_for(sentinel_endpoint)
 
             begin
               address = client.call('sentinel', 'get-master-addr-by-name', @master_name)
@@ -40,7 +52,7 @@ module ThreeScale
 
         def resolve_slave
           @sentinel_endpoints.each do |sentinel_endpoint|
-            client = Async::Redis::Client.new(sentinel_endpoint, protocol: Protocol::ExtendedRESP2.new(credentials: @sentinel_credentials))
+            client = sentinel_client_for(sentinel_endpoint)
 
             begin
               reply = client.call('sentinel', 'slaves', @master_name)

--- a/lib/3scale/backend/async_redis/sentinels_client_acl_tls.rb
+++ b/lib/3scale/backend/async_redis/sentinels_client_acl_tls.rb
@@ -22,7 +22,11 @@ module ThreeScale
         end
 
         def close
-          @sentinel_clients.each_value(&:close)
+          @sentinel_clients.each_value do |client|
+            client.close
+          rescue StandardError => error
+            Backend.logger.warn "Failed to close sentinel connection: #{error.message}"
+          end
           @sentinel_clients.clear
           super
         end

--- a/lib/3scale/backend/storage_async/client.rb
+++ b/lib/3scale/backend/storage_async/client.rb
@@ -72,16 +72,20 @@ module ThreeScale
 
         private
 
+        # Retries the block on connection errors without destroying the
+        # client. The underlying pool already handles individual dead
+        # connections by retiring them and creating new ones via its
+        # constructor block (which re-resolves the master through
+        # sentinels). We just need to wait before retrying so we don't
+        # spin during a master failover.
         def with_reconnect
           attempt = 0
           begin
-           yield connect
+            yield connect
           rescue *CONNECTION_ERRORS => e
-            close
-
             if attempt < @opts[:reconnect_attempts]
-              Backend.logger.warn "Failed Redis connect (attempt #{attempt+1}/#{@opts[:reconnect_attempts]}): #{e.message}"
               attempt += 1
+              Backend.logger.warn "Redis connection lost, reconnecting (attempt #{attempt}/#{@opts[:reconnect_attempts]}): #{e.message}"
               sleep @opts[:reconnect_wait_seconds]
               retry
             else


### PR DESCRIPTION
**Jira Issue:**

https://redhat.atlassian.net/browse/THREESCALE-14671

**Description:**

Apisonator 2.16.3 is still leaking connections. That's because the hotfix I wrote for THREESCALE-11941, which was released in 2.16.3, fixes the connections leaking to the redis masters, but when connecting to sentinels, the connections to sentinels themselves are being leaked too.

The bug is in the methods to resolve the master and slave address from the sentinels client class. Those methods open a connection to redis but never close it. For some reason, those connections are not being being GCd when the methods return. According to Claude, because the calling `Task` is kept alive and the `Async` reactor holds a reference during all process life.

This PR fixes the bug by:

1. Caching the connections so they are reused
2. Ensuring the connections are closed by overriding the close method
3. Limiting sentinels connection pool to 1. This is redundant according to Claude, but still.