### PR TITLE
THREESCALE-14798: return 400 for query parameter limit exceeded

### DIFF
--- a/lib/3scale/backend/logging/middleware/writer.rb
+++ b/lib/3scale/backend/logging/middleware/writer.rb
@@ -109,7 +109,7 @@ module ThreeScale
             if env[REQUEST_METHOD].to_s.upcase == STR_POST
               provider_key = begin
                 ::Rack::Request.new(env).params[STR_PROVIDER_KEY]
-              rescue IOError
+              rescue IOError, ::Rack::QueryParser::QueryLimitError
                 # happens when body does not parse
                 nil
               end

--- a/lib/3scale/backend/rack/exception_catcher.rb
+++ b/lib/3scale/backend/rack/exception_catcher.rb
@@ -41,27 +41,19 @@ module ThreeScale
           delete_sinatra_error! env
           respond_with e.http_code, prepare_body(e.to_xml, env)
         rescue ArgumentError => e
-          return unhandled_exception(e) unless e.message.include?(INVALID_BYTE_SEQUENCE_ERR_MSG)
+          raise e unless e.message.include?(INVALID_BYTE_SEQUENCE_ERR_MSG)
 
+          error = Backend::NotValidData.new
           delete_sinatra_error! env
-          respond_with 400, Backend::NotValidData.new.to_xml
-        rescue Exception => e
-          unhandled_exception(e)
+          respond_with error.http_code, error.to_xml
+        rescue ::Rack::QueryParser::QueryLimitError => e
+          delete_sinatra_error! env
+
+          error = Backend::BadRequest.new(e.message)
+          respond_with error.http_code, error.to_xml
         end
 
         private
-
-        # raise up the chain an unhandled exception - but test first for an edge
-        # case with Rack key space limit for parsing requests.
-        # See https://github.com/rack/rack/blob/2.0.4/lib/rack/query_parser.rb#L166
-        def unhandled_exception(e)
-          if e.class == RangeError &&
-              e.message == 'exceeded available parameter key space'.freeze
-            respond_with 400, Backend::NotValidData.new.to_xml
-          else
-            raise e
-          end
-        end
 
         # Private: Deletes 'sinatra.error' key in Rack's env hash.
         # Some external services report 'sinatra.error' and we don't want it when
@@ -74,7 +66,7 @@ module ThreeScale
           env['sinatra.error'.freeze] = nil
         end
 
-        # Private: Prepares the body to include in the reponse.
+        # Private: Prepares the body to include in the response.
         #
         # body - Proposed body String.
         # env - The environment Hash.

--- a/test/integration/authorize/basic_test.rb
+++ b/test/integration/authorize/basic_test.rb
@@ -441,16 +441,16 @@ class AuthorizeBasicTest < Test::Unit::TestCase
   test 'regression test for utf8 issues and super malformed request' do
     get '/transactions/authorize.xml', :provider_key => "\xf0\x90\x28\xbc"
 
-    assert_equal 400, last_response.status
-    assert_error_response :status  => 400,
+    assert_equal 422, last_response.status
+    assert_error_response :status  => 422,
                           :code    => 'not_valid_data',
                           :message => 'all data must be valid UTF8'
 
     get '/transactions/authorize.xml', :provider_key => @provider_key,
                                         :app_id => "\xf0\x90\x28\xbc"
 
-    assert_equal 400, last_response.status
-    assert_error_response :status  => 400,
+    assert_equal 422, last_response.status
+    assert_error_response :status  => 422,
                           :code    => 'not_valid_data',
                           :message => 'all data must be valid UTF8'
 
@@ -458,8 +458,8 @@ class AuthorizeBasicTest < Test::Unit::TestCase
                                         :app_id => @application.id,
                                         :app_key => "\xf0\x90\x28\xbc"
 
-    assert_equal 400, last_response.status
-    assert_error_response :status  => 400,
+    assert_equal 422, last_response.status
+    assert_error_response :status  => 422,
                           :code    => 'not_valid_data',
                           :message => 'all data must be valid UTF8'
 
@@ -467,7 +467,7 @@ class AuthorizeBasicTest < Test::Unit::TestCase
                                         :app_id => @application.id,
                                         :usage => {"\xf0\x90\x28\xbc" => 1}
 
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
 
   end
 

--- a/test/integration/listener_test.rb
+++ b/test/integration/listener_test.rb
@@ -65,6 +65,43 @@ class ListenerTest < Test::Unit::TestCase
     assert_equal 'bad_request', node['code']
   end
 
+  def test_query_parameter_limit_exceeded
+    params = (0..2050).map { |i|
+      "transactions[#{i}][user_key]=uk&transactions[#{i}][usage][hits]=1"
+    }.join('&')
+
+    post '/transactions.xml', params
+
+    assert_equal 400, last_response.status
+
+    node = xml.at('error')
+    assert_match(/total number of query parameters \(\d+\) exceeds limit/, node.content)
+    assert_equal 'bad_request', node['code']
+  end
+
+  def test_query_bytesize_limit_exceeded
+    big_value = 'x' * (4 * 1024 * 1024 + 1)
+
+    post '/transactions.xml', "big=#{big_value}"
+
+    assert_equal 400, last_response.status
+
+    node = xml.at('error')
+    assert_match(/total query size exceeds limit/, node.content)
+
+    assert_equal 'bad_request', node['code']
+  end
+
+  def test_invalid_utf8_byte_sequence
+    get '/transactions/authorize.xml?service_token=foo&user_key=%ff%fe'
+
+    assert_equal 422, last_response.status
+
+    node = xml.at('error')
+    assert_match(/all data must be valid UTF8/, node.content)
+    assert_equal 'not_valid_data', node['code']
+  end
+
   def test_unsupported_end_users_auth
     get '/transactions/authorize.xml', provider_key: 'pk', user_id: '123'
     check_end_users_not_supported_error(last_response)

--- a/test/integration/logger_test.rb
+++ b/test/integration/logger_test.rb
@@ -22,6 +22,18 @@ class LoggerTest < Test::Unit::TestCase
     end
   end
 
+  test 'log does not raise when query parameter limit is exceeded' do
+    params = (0..2050).map { |i|
+      "transactions[#{i}][user_key]=uk&transactions[#{i}][usage][hits]=1"
+    }.join('&')
+
+    default_log_writer.any_instance.expects(:log).once
+
+    assert_nothing_raised do
+      post '/transactions.xml', params
+    end
+  end
+
   test 'log failed requests with request info and error info' do
     redis = Backend::Storage.instance
     redis.expects(:get).raises(Timeout::Error)

--- a/test/integration/report_test.rb
+++ b/test/integration/report_test.rb
@@ -944,21 +944,21 @@ class ReportTest < Test::Unit::TestCase
     assert_error_resp_with_exc(ThreeScale::Backend::ProviderKeyOrServiceTokenRequired.new)
   end
 
-  test 'returns 400 when param key encoding is not valid utf-8' do
+  test 'returns 422 when param key encoding is not valid utf-8' do
     post '/transactions.xml',
          :provider_key => @provider_key,
          "\xf0\x90\x28\xbc" => 1
 
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
     assert_equal ThreeScale::Backend::NotValidData.new.to_xml, last_response.body
   end
 
-  test 'returns 400 when transactions do not have valid utf-8 encoding and is not a hash' do
+  test 'returns 422 when transactions do not have valid utf-8 encoding and is not a hash' do
     post '/transactions.xml',
       :provider_key => @provider_key,
       :transactions => "\xf0\x90\x28\xbc"
 
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
     assert_equal ThreeScale::Backend::NotValidData.new.to_xml, last_response.body
   end
 
@@ -973,19 +973,19 @@ class ReportTest < Test::Unit::TestCase
     assert_error_resp_with_exc(ThreeScale::Backend::TransactionsFormatInvalid.new)
   end
 
-  test 'returns 400 and not valid data msg when params have an invalid encoding' do
+  test 'returns 422 and not valid data msg when params have an invalid encoding' do
     post '/transactions.xml',
       :provider_key => @provider_key,
       :transactions => {"\xf0\x90\x28\xbc" => {:app_id => @application.id}}
 
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
     assert_equal ThreeScale::Backend::NotValidData.new.to_xml, last_response.body
 
     post '/transactions.xml',
       :provider_key => @provider_key,
       :transactions => {'0' => {:app_id => @application.id, :usage => {"\xf0\x90\x28\xbc" => 1}}}
 
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
     assert_equal ThreeScale::Backend::NotValidData.new.to_xml, last_response.body
 
     post '/transactions.xml',
@@ -993,21 +993,21 @@ class ReportTest < Test::Unit::TestCase
       :service_id => "\xf0\x90\x28\xbc",
       :transactions => {'0' => {:app_id => @application.id, :usage => {'hits' => 1}}}
 
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
     assert_equal ThreeScale::Backend::NotValidData.new.to_xml, last_response.body
 
     post '/transactions.xml',
       :provider_key => @provider_key,
       :transactions => {0 => {:app_id => "\xf0\x90\x28\xbc"}}
 
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
     assert_equal ThreeScale::Backend::NotValidData.new.to_xml, last_response.body
 
     post '/transactions.xml',
       :provider_key => @provider_key,
       :transactions => {'0' => {:app_id => @application.id, :usage => {'hits' => "\xf0\x90\x28\xbc"}}}
 
-    assert_equal 400, last_response.status
+    assert_equal 422, last_response.status
     assert_equal ThreeScale::Backend::NotValidData.new.to_xml, last_response.body
   end
 


### PR DESCRIPTION
When a POST request body exceeds Rack's 4096 parameter limit, Rack raises QueryLimitError. Previously this surfaced as a 500.

Two things caused the 500: first, the ExceptionCatcher middleware did not handle QueryLimitError, so it propagated unhandled. Second, when the logging middleware tried to log the error, its extract_query_string method called request.params which triggered the same QueryLimitError again, since it only rescued IOError.

Now the ExceptionCatcher returns 400 Bad Request with the error message in XML, and the logging middleware rescues the error gracefully when extracting query string parameters.

**Jira issue:**

https://redhat.atlassian.net/browse/THREESCALE-14798