### PR TITLE
THREESCALE-14823: Fix async Redis client leak in retry logic

### DIFF
--- a/lib/3scale/backend/storage_async/client.rb
+++ b/lib/3scale/backend/storage_async/client.rb
@@ -74,16 +74,20 @@ module ThreeScale
 
         private
 
+        # Retries the block on connection errors without destroying the
+        # client. The underlying pool already handles individual dead
+        # connections by retiring them and creating new ones via its
+        # constructor block (which re-resolves the master through
+        # sentinels). We just need to wait before retrying so we don't
+        # spin during a master failover.
         def with_reconnect
           attempt = 0
           begin
-           yield connect
+            yield connect
           rescue *CONNECTION_ERRORS => e
-            close
-
             if attempt < @opts[:reconnect_attempts]
-              Backend.logger.warn "Failed Redis connect (attempt #{attempt+1}/#{@opts[:reconnect_attempts]}): #{e.message}"
               attempt += 1
+              Backend.logger.warn "Redis connection lost, reconnecting (attempt #{attempt}/#{@opts[:reconnect_attempts]}): #{e.message}"
               sleep @opts[:reconnect_wait_seconds]
               retry
             else

--- a/spec/unit/storage_async/client_spec.rb
+++ b/spec/unit/storage_async/client_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+if ThreeScale::Backend.configuration.redis.async
+  module ThreeScale
+    module Backend
+      module StorageAsync
+        describe Client do
+          let(:opts) do
+            {
+              url: 'redis://localhost:6379',
+              reconnect_attempts: 2,
+              reconnect_wait_seconds: 0,
+              max_connections: 10
+            }
+          end
+          let(:client) { described_class.new(opts) }
+          let(:fake_conn) { double('async_redis_client') }
+
+          before do
+            allow(AsyncRedis::Client).to receive(:connect).and_return(fake_conn)
+          end
+
+          describe 'with_reconnect' do
+            context 'when a connection error occurs and then recovers' do
+              it 'retries without replacing the underlying client' do
+                call_count = 0
+                allow(fake_conn).to receive(:call) do
+                  call_count += 1
+                  raise Errno::ECONNRESET if call_count == 1
+                  'PONG'
+                end
+
+                result = client.call('PING')
+
+                expect(result).to eq('PONG')
+                expect(AsyncRedis::Client).to have_received(:connect).once
+              end
+            end
+
+            context 'when all retry attempts are exhausted' do
+              it 'raises the connection error' do
+                allow(fake_conn).to receive(:call).and_raise(Errno::ECONNRESET)
+
+                expect { client.call('PING') }.to raise_error(Errno::ECONNRESET)
+              end
+
+              it 'does not replace the underlying client between attempts' do
+                allow(fake_conn).to receive(:call).and_raise(Errno::ECONNRESET)
+
+                client.call('PING') rescue nil
+
+                expect(AsyncRedis::Client).to have_received(:connect).once
+              end
+            end
+
+            context 'when multiple fibers fail concurrently' do
+              let(:concurrency) { 10 }
+
+              it 'reuses the same client instance across all fibers' do
+                failed_fibers = {}
+                allow(fake_conn).to receive(:call) do
+                  fiber = Fiber.current
+                  unless failed_fibers[fiber]
+                    failed_fibers[fiber] = true
+                    raise Errno::ECONNRESET
+                  end
+                  'PONG'
+                end
+
+                barrier = Async::Barrier.new
+                concurrency.times { barrier.async { client.call('PING') } }
+                barrier.wait
+
+                expect(AsyncRedis::Client).to have_received(:connect).once
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+else
+  describe 'StorageAsync::Client' do
+    it 'is skipped when not running in async mode' do
+      skip 'This test only runs in async mode'
+    end
+  end
+end


### PR DESCRIPTION
**Jira issue:**

https://redhat.atlassian.net/browse/THREESCALE-14823

**Description:**

After backporting the hotfix for **THREESCALE-14671**. I tested the same scenarios in the `master` branch and I found that one of the leaks is in fact reproducible also in `master`.

See the jira description for a more detailed explanation, but summarizing, these were the two leaking scenarios:

1. **Connections to sentinels being disposable:** This could be fine, but the GC was not working properly and the disposable clients were not being disposed, therefore, leaking the connections. The solution to this was caching and reusing the sentinels connections instead of making them disposable. In `master`, this is not a problem because we replaced our buggy module by the `async-redis` gem class, which already caches the clients.
2. **Retry logic:** The retry logic was buggy and multiple fibers failing at the same time were causing the same shared client `@redis_async` to be opened and closed multiple times. And leaking a connection each time, due to the GC problem. This happens also in `master`, and this PR fixes it by removing the calls to `close`. That way the same `@redis_async` instance is reused, and the same connection pools continue to allocate and discard connections properly without leaking. That is, the connection management gets delegated to the connection pools.